### PR TITLE
Require wg.service and start on boot

### DIFF
--- a/nixarr/jellyfin/default.nix
+++ b/nixarr/jellyfin/default.nix
@@ -115,6 +115,10 @@ in {
         )
       ];
 
+      systemd.services."container@jellyfin" = mkIf cfg.vpn.enable {
+        requires = ["wg.service"];
+      };
+
       containers.jellyfin = mkIf cfg.vpn.enable {
         autoStart = true;
         ephemeral = true;

--- a/nixarr/lidarr/default.nix
+++ b/nixarr/lidarr/default.nix
@@ -40,6 +40,10 @@ in {
       )
     ];
 
+    systemd.services."container@lidarr" = mkIf cfg.vpn.enable {
+      requires = ["wg.service"];
+    };
+
     containers.lidarr = mkIf cfg.vpn.enable {
       autoStart = true;
       ephemeral = true;

--- a/nixarr/prowlarr/default.nix
+++ b/nixarr/prowlarr/default.nix
@@ -45,6 +45,10 @@ in {
       )
     ];
 
+    systemd.services."container@prowlarr" = mkIf cfg.vpn.enable {
+      requires = ["wg.service"];
+    };
+
     containers.prowlarr = mkIf cfg.vpn.enable {
       autoStart = true;
       ephemeral = true;

--- a/nixarr/radarr/default.nix
+++ b/nixarr/radarr/default.nix
@@ -43,6 +43,10 @@ in {
       )
     ];
 
+    systemd.services."container@radarr" = mkIf cfg.vpn.enable {
+      requires = ["wg.service"];
+    };
+
     containers.radarr = mkIf cfg.vpn.enable {
       autoStart = true;
       ephemeral = true;

--- a/nixarr/readarr/default.nix
+++ b/nixarr/readarr/default.nix
@@ -40,6 +40,10 @@ in {
       )
     ];
 
+    systemd.services."container@readarr" = mkIf cfg.vpn.enable {
+      requires = ["wg.service"];
+    };
+
     containers.readarr = mkIf cfg.vpn.enable {
       autoStart = true;
       ephemeral = true;

--- a/nixarr/sonarr/default.nix
+++ b/nixarr/sonarr/default.nix
@@ -44,6 +44,10 @@ in {
       })
     ];
 
+    systemd.services."container@sonarr" = mkIf cfg.vpn.enable {
+      requires = ["wg.service"];
+    };
+
     containers.sonarr = mkIf cfg.vpn.enable {
       autoStart = true;
       ephemeral = true;

--- a/nixarr/transmission/default.nix
+++ b/nixarr/transmission/default.nix
@@ -119,6 +119,10 @@ in {
       openTcpPorts = [cfg.peerPort];
     };
 
+    systemd.services."container@transmission" = mkIf cfg.vpn.enable {
+      requires = ["wg.service"];
+    };
+
     containers.transmission = mkIf cfg.vpn.enable {
       autoStart = true;
       ephemeral = true;

--- a/util/vpnNamespace/default.nix
+++ b/util/vpnNamespace/default.nix
@@ -208,7 +208,7 @@ in {
           bindsTo = ["netns@wg.service"];
           requires = ["network-online.target"];
           after = ["netns@wg.service"];
-          wantedBy = ["netns@wg.service"];
+          wantedBy = ["multi-user.target"];
 
           serviceConfig = let
             lines = split "\n" (readFile cfg.wireguardConfigFile);


### PR DESCRIPTION
Fixes #6 

The WantedBy directive is used to start the service on boot regardless of whether other services depend on it.
This eliminates confusion as it is probably expected that the namespace, interface etc. exists when the module is enabled. It is also useful in case users need the namespace without necessarily having other services that depend on it.

The Requires directive might not be strictly necessary, but is used to make absolutely sure that the wg service has been started and hence that the namespace exists at /var/run/netns/wg