### PR TITLE
mkIf around vpnnamespaces.wg

### DIFF
--- a/nixarr/nixarr.nix
+++ b/nixarr/nixarr.nix
@@ -181,8 +181,8 @@ in {
     ];
 
     # TODO: wtf to do about openports
-    vpnnamespaces.wg = {
-      enable = cfg.vpn.enable ;
+    vpnnamespaces.wg = mkIf cfg.vpn.enable {
+      enable = true;
       accessibleFrom = [
         "192.168.1.0/24"
         "127.0.0.1"


### PR DESCRIPTION
Small change to avoid nix errors when not using a vpn, seems like `vpnnamespaces.wg.wireguardConfigFile` gets read from even when `vpnnamespaces.wg.enable` is false

![image](https://github.com/rasmus-kirk/nixarr/assets/9365365/66feea1b-642d-4a02-97c9-7a59eb3c035e)
