### PR TITLE
Add class A IPs to `accessibleFrom`

### DIFF
--- a/nixarr/nixarr.nix
+++ b/nixarr/nixarr.nix
@@ -276,6 +276,7 @@ in {
       };
       accessibleFrom = [
         "192.168.1.0/24"
+        "10.0.0.0/8"
         "127.0.0.1"
       ];
       wireguardConfigFile = cfg.vpn.wgConf;

--- a/nixarr/transmission/default.nix
+++ b/nixarr/transmission/default.nix
@@ -335,7 +335,7 @@ in {
           rpc-port = cfg.uiPort;
           rpc-whitelist-enabled = true;
           rpc-whitelist = strings.concatStringsSep "," ([
-            "127.0.0.1,192.168.*" # Defaults
+            "127.0.0.1,192.168.*,10.*" # Defaults
           ] ++ cfg.extraAllowedIps);
           rpc-authentication-required = false;
 


### PR DESCRIPTION
Was having a lot of trouble viewing transmission webUI over LAN with VPN enabled. Turns out it was because my LAN IP address is `10.0.0.69` and that isn't included in `vpnnamespaces.wg.accessibleFrom`. 