### PR TITLE
fix: remove stale nixpkgs override for vpnconfinement

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     vpnconfinement.url = "github:Maroka-chan/VPN-Confinement";
-    vpnconfinement.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = {


### PR DESCRIPTION
This gets rid of a pesky warning:
`warning: input 'vpnconfinement' has an override for a non-existent input 'nixpkgs'`

VPN Confinement flake no longer has a nixpkgs input since https://github.com/Maroka-chan/VPN-Confinement/commit/243596714598ef19255777c9ff8fe7ecc7482c04.