### PR TITLE
fix(sabnzbd): fixed lidarr path typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Updated:
 Updated:
 - VPNConfinement submodule
 
+## 2024-05-09
+
+Fixed:
+- Jellyfin now has highest IO priority and transmission has lowest
+
 ## 2024-03-12
 
 Added:

--- a/nixarr/sabnzbd/default.nix
+++ b/nixarr/sabnzbd/default.nix
@@ -191,7 +191,7 @@ in {
         "d '${nixarr.mediaDir}/usenet/.incomplete' 0755 usenet media - -"
         "d '${nixarr.mediaDir}/usenet/.watch'      0755 usenet media - -"
         "d '${nixarr.mediaDir}/usenet/manual'      0775 usenet media - -"
-        "d '${nixarr.mediaDir}/usenet/liadarr'     0775 usenet media - -"
+        "d '${nixarr.mediaDir}/usenet/lidarr'      0775 usenet media - -"
         "d '${nixarr.mediaDir}/usenet/radarr'      0775 usenet media - -"
         "d '${nixarr.mediaDir}/usenet/sonarr'      0775 usenet media - -"
         "d '${nixarr.mediaDir}/usenet/readarr'     0775 usenet media - -"


### PR DESCRIPTION
Fixes a typo in sabnzbd's media dirs for lidarr.