### PR TITLE
feat: qbittorrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that I will remove or change options in a non-backwards-compatible way.
 ## Features
 
 - **Run services through a VPN:** You can run any service that this module
-  supports through a VPN, fx `nixarr.transmission.vpn.enable = true;`
+  supports through a VPN, fx `nixarr.transmission.vpn.enable = true;` or `nixarr.qbittorrent.vpn.enable = true;`
 - **Automatic Directories, Users and Permissions:** The module automatically
   creates directories and users for your media library. It also sets sane
   permissions.

--- a/docs/wiki/examples/example-1/index.md
+++ b/docs/wiki/examples/example-1/index.md
@@ -41,6 +41,13 @@ This example does the following:
       peerPort = 50000; # Set this to the port forwarded by your VPN
     };
 
+    # Alternatively, you can use qBittorrent instead of transmission:
+    # qbittorrent = {
+    #   enable = true;
+    #   vpn.enable = true;
+    #   peerPort = 50000; # Set this to the port forwarded by your VPN
+    # };
+
     # It is possible for this module to run the *Arrs through a VPN, but it
     # is generally not recommended, as it can cause rate-limiting issues.
     bazarr.enable = true;

--- a/docs/wiki/examples/example-2/index.md
+++ b/docs/wiki/examples/example-2/index.md
@@ -33,6 +33,13 @@ example does the following:
       peerPort = 50000; # Set this to the port forwarded by your VPN
     };
 
+    # Alternatively, you can use qBittorrent instead of transmission:
+    # qbittorrent = {
+    #   enable = true;
+    #   vpn.enable = true;
+    #   peerPort = 50000; # Set this to the port forwarded by your VPN
+    # };
+
     bazarr.enable = true;
     sonarr.enable = true;
     radarr.enable = true;

--- a/docs/wiki/vpn/ports/index.md
+++ b/docs/wiki/vpn/ports/index.md
@@ -27,6 +27,16 @@ Then you can set that port for a service, for example
   };
 ```
 
+Or with qBittorrent:
+
+```nix {.numberLines}
+  nixarr.qbittorrent = {
+    enable = true;
+    vpn.enable = true;
+    peerPort = 12345;
+  };
+```
+
 ## Debugging Ports
 
 > **Note:** See [this GH issue](https://github.com/rasmus-kirk/nixarr/issues/27)

--- a/nixarr/default.nix
+++ b/nixarr/default.nix
@@ -27,6 +27,7 @@ in {
     ./sabnzbd
     ./sonarr
     ./transmission
+    ./qbittorrent
     ../util
   ];
 

--- a/nixarr/qbittorrent/default.nix
+++ b/nixarr/qbittorrent/default.nix
@@ -1,0 +1,198 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.nixarr.qbittorrent;
+  globals = config.util-nixarr.globals;
+  nixarr = config.nixarr;
+in {
+  options.nixarr.qbittorrent = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether or not to enable the qBittorrent service.
+
+        **Required options:** [`nixarr.enable`](#nixarr.enable)
+      '';
+    };
+
+    package = mkPackageOption pkgs "qbittorrent-nox" {};
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "${nixarr.stateDir}/qbittorrent";
+      defaultText = literalExpression ''"''${nixarr.stateDir}/qbittorrent"'';
+      example = "/nixarr/.state/qbittorrent";
+      description = ''
+        The location of the state directory for the qBittorrent service.
+
+        > **Warning:** Setting this to any path, where the subpath is not
+        > owned by root, will fail! For example:
+        >
+        > ```nix
+        >   stateDir = /home/user/nixarr/.state/qbittorrent
+        > ```
+        >
+        > Is not supported, because `/home/user` is owned by `user`.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      defaultText = literalExpression ''!nixarr.qbittorrent.vpn.enable'';
+      default = !cfg.vpn.enable;
+      example = true;
+      description = "Open firewall for qBittorrent web UI and BitTorrent ports.";
+    };
+
+    vpn.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        **Required options:** [`nixarr.vpn.enable`](#nixarr.vpn.enable)
+
+        Route qBittorrent traffic through the VPN.
+      '';
+    };
+
+    uiPort = mkOption {
+      type = types.port;
+      default = 8080;
+      example = 8080;
+      description = "qBittorrent web UI port.";
+    };
+
+    peerPort = mkOption {
+      type = types.port;
+      default = 32189;
+      example = 32189;
+      description = "qBittorrent BitTorrent protocol port.";
+    };
+  };
+
+  config = mkIf (nixarr.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = cfg.enable -> nixarr.enable;
+        message = ''
+          The nixarr.qbittorrent.enable option requires the
+          nixarr.enable option to be set, but it was not.
+        '';
+      }
+      {
+        assertion = cfg.vpn.enable -> nixarr.vpn.enable;
+        message = ''
+          The nixarr.qbittorrent.vpn.enable option requires the
+          nixarr.vpn.enable option to be set, but it was not.
+        '';
+      }
+    ];
+
+    users = {
+      groups.${globals.qbittorrent.group}.gid = globals.gids.${globals.qbittorrent.group};
+      users.${globals.qbittorrent.user} = {
+        isSystemUser = true;
+        group = globals.qbittorrent.group;
+        uid = globals.uids.${globals.qbittorrent.user};
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.stateDir}'                          0750 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+
+      # Media directories
+      "d '${nixarr.mediaDir}/torrents'              0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+      "d '${nixarr.mediaDir}/torrents/.incomplete'  0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+      "d '${nixarr.mediaDir}/torrents/manual'       0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+      "d '${nixarr.mediaDir}/torrents/lidarr'       0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+      "d '${nixarr.mediaDir}/torrents/radarr'       0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+      "d '${nixarr.mediaDir}/torrents/sonarr'       0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+      "d '${nixarr.mediaDir}/torrents/readarr'      0755 ${globals.qbittorrent.user} ${globals.qbittorrent.group} - -"
+    ];
+
+    systemd.services.qbittorrent = {
+      description = "qBittorrent BitTorrent client";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = globals.qbittorrent.user;
+        Group = globals.qbittorrent.group;
+        ExecStart = "${cfg.package}/bin/qbittorrent-nox";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "off";
+        ProtectHome = false;
+        
+        # Always prioritize all other services wrt. IO
+        IOSchedulingPriority = 7;
+      };
+
+      environment = {
+        WEBUI_PORT = toString cfg.uiPort;
+        HOME = cfg.stateDir;
+        XDG_CONFIG_HOME = cfg.stateDir;
+        XDG_DATA_HOME = cfg.stateDir;
+      };
+    };
+
+    # Enable and specify VPN namespace to confine service in.
+    systemd.services.qbittorrent.vpnConfinement = mkIf cfg.vpn.enable {
+      enable = true;
+      vpnNamespace = "wg";
+    };
+
+    # Port mappings
+    vpnNamespaces.wg = mkIf cfg.vpn.enable {
+      portMappings = [
+        {
+          from = cfg.uiPort;
+          to = cfg.uiPort;
+        }
+      ];
+      openVPNPorts = [
+        {
+          port = cfg.peerPort;
+          protocol = "both";
+        }
+      ];
+    };
+
+    services.nginx = mkIf cfg.vpn.enable {
+      enable = true;
+
+      recommendedTlsSettings = true;
+      recommendedOptimisation = true;
+      recommendedGzipSettings = true;
+
+      virtualHosts."127.0.0.1:${builtins.toString cfg.uiPort}" = {
+        listen = [
+          {
+            addr = "0.0.0.0";
+            port = cfg.uiPort;
+          }
+        ];
+        locations."/" = {
+          recommendedProxySettings = true;
+          proxyWebsockets = true;
+          proxyPass = "http://192.168.15.1:${builtins.toString cfg.uiPort}";
+        };
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.uiPort cfg.peerPort ];
+      allowedUDPPorts = [ cfg.peerPort ];
+    };
+  };
+}

--- a/util/globals/default.nix
+++ b/util/globals/default.nix
@@ -35,6 +35,7 @@ in {
       sabnzbd = 38;
       transmission = 70;
       cross-seed = 183;
+      qbittorrent = 71;
     };
     gids = {
       autobrr = 188;
@@ -108,6 +109,10 @@ in {
     cross-seed = {
       user = "cross-seed";
       group = "cross-seed";
+    };
+    qbittorrent = {
+      user = "qbittorrent";
+      group = globals.libraryOwner.group;
     };
   };
 }


### PR DESCRIPTION
Adds [qBittorrent](https://www.qbittorrent.org/) as an alternative to Transmission for BitTorrent downloading.
I've based this on the existing transmission module with similar options and VPN integration. 

Tested on my own machine using my fork.