### PR TITLE
Set bazarr's systemd config KillSignal to SIGINIT to fix timeout

### DIFF
--- a/nixarr/bazarr/default.nix
+++ b/nixarr/bazarr/default.nix
@@ -99,6 +99,8 @@ in {
             --no-update True
         '';
         Restart = "on-failure";
+        KillSignal = "SIGINT";
+        SuccessExitStatus = "0 156";
       };
     };
 


### PR DESCRIPTION
Hello!

Bazarr is not stopping gracefully (at least for me), and instead it blocks during 90s until timeout. I have investigated the issue, and this problem has already been fixed in [nixpkgs](https://github.com/NixOS/nixpkgs/pull/334675)

This pull request replicates the [nixpkgs patch](https://github.com/NixOS/nixpkgs/pull/334675/commits) here.