### PR TITLE
fix: remove hardcoded torrenter user and missing globals reference

### DIFF
--- a/nixarr/transmission/cross-seed/default.nix
+++ b/nixarr/transmission/cross-seed/default.nix
@@ -6,6 +6,7 @@
 }:
 with lib; let
   cfg = config.util-nixarr.services.cross-seed;
+  globals = config.util-nixarr.globals;
   settingsFormat = pkgs.formats.json {};
   settingsFile = settingsFormat.generate "settings.json" cfg.settings;
   configJs = pkgs.writeText "config.js" ''

--- a/nixarr/transmission/default.nix
+++ b/nixarr/transmission/default.nix
@@ -31,7 +31,7 @@ with lib; let
       text = ''
         touch ${cfg.stateDir}/prowlarr-api-key
         chmod 400 ${cfg.stateDir}/prowlarr-api-key
-        chown torrenter ${cfg.stateDir}/prowlarr-api-key
+        chown ${globals.transmission.user} ${cfg.stateDir}/prowlarr-api-key
         xq -r '.Config.ApiKey' "${nixarr.prowlarr.stateDir}/config.xml" > "${cfg.stateDir}/prowlarr-api-key"
       '';
     };


### PR DESCRIPTION
Fixes two issues for the transmission module:

* undefined reference to `globals`
* hardcoded `torrenter` user in prowlarr API key generation