### PR TITLE
Kill bazarr with SIGINT

### DIFF
--- a/nixarr/bazarr/default.nix
+++ b/nixarr/bazarr/default.nix
@@ -98,6 +98,7 @@ in {
             --port ${toString cfg.port} \
             --no-update True
         '';
+        KillSignal = "SIGINT";
         Restart = "on-failure";
       };
     };


### PR DESCRIPTION
It's already done in NixOS: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/misc/bazarr.nix#L72.

Reasoning why this works can be found at https://dietpi.com/forum/t/a-stop-job-is-running-for-bazarr-dietpi-when-shutting-down-the-system/19610/11. Otherwise it takes very long to stop.