### PR TITLE
preserve env var yaml tags for recyclarr config

### DIFF
--- a/nixarr/recyclarr/default.nix
+++ b/nixarr/recyclarr/default.nix
@@ -8,10 +8,14 @@ with lib; let
   cfg = config.nixarr.recyclarr;
   globals = config.util-nixarr.globals;
   nixarr = config.nixarr;
+  # This is a carbon copy of the yaml implementation in nixpkgs https://github.com/NixOS/nixpkgs/blob/fde6c4aec177afa2d0248b1c5983e2a72a231442/pkgs/pkgs-lib/formats.nix#L210-L231
+  # except we've replaced json2yaml for yq-go to allow it to parse custom yaml tags
+  # ideally this would some day be upstreamed, see https://github.com/NixOS/nix/issues/4910 and https://github.com/rasmus-kirk/nixarr/issues/91
   yamlGenerator = {preserved-tags ? []}: let
     selectors =
-      pkgs.lib.strings.concatStringsSep "/"
+      pkgs.lib.strings.concatStringsSep "|"
       (builtins.map (
+          # this is yq for "for all the scalers, if they match this regex, do a regex substitution and set the tag"
           x: ''
             with((.. | select(kind == "scalar") | select(test("^!${x} .*"))); . = sub("!${x} ", "") | . tag="!${x}")
           ''


### PR DESCRIPTION
fixes #91

if we need this for other things it might be smart to move the function out of the recyclarr file