### PR TITLE
Multi instance support radarr and sonarr

### DIFF
--- a/nixarr/lib/api-keys.nix
+++ b/nixarr/lib/api-keys.nix
@@ -60,8 +60,10 @@ with lib; let
 
   servicesWithApiKeys = builtins.attrNames printServiceApiKey;
 
+  xq = getExe' pkgs.yq "xq";
+
   # Helper to create API key extraction for a service
-  mkApiKeyExtractor = serviceName: {
+  mkApiKeyExtractor = serviceName: cfgFilePath: printScript: {
     description = "Extract ${serviceName} API key";
     after = ["${serviceName}.service"];
     requires = ["${serviceName}.service"];
@@ -74,29 +76,66 @@ with lib; let
 
       ExecStartPre = [
         (pkgs.writeShellScript "wait-for-${serviceName}-config" ''
-          while [ ! -f '${serviceCfgFile.${serviceName}}' ]; do sleep 1; done
+          while [ ! -f '${cfgFilePath}' ]; do sleep 1; done
         '')
       ];
 
       ExecStart = pkgs.writeShellScript "extract-${serviceName}-api-key" ''
-        ${printServiceApiKey.${serviceName}} > '${cfg.stateDir}/api-keys/${serviceName}.key'
+        ${printScript} > '${cfg.stateDir}/api-keys/${serviceName}.key'
       '';
     };
   };
+
+  # Generate API key extractors for radarr/sonarr instances
+  mkInstanceApiKeys = service:
+    let
+      instancesCfg = cfg.${service}.instances;
+      enabledInstances = filterAttrs (_: inst: inst.enable) instancesCfg;
+    in
+      mapAttrsToList (name: inst:
+        let
+          instanceStateDir =
+            if inst.stateDir != null
+            then inst.stateDir
+            else "${cfg.${service}.stateDir}-${name}";
+          cfgFilePath = "${instanceStateDir}/config.xml";
+          serviceName = "${service}-${name}";
+          printScript = pkgs.writeShellScript "print-${serviceName}-api-key" ''
+            ${xq} -r .Config.ApiKey '${cfgFilePath}'
+          '';
+        in {
+          inherit serviceName cfgFilePath printScript;
+        }
+      ) enabledInstances;
+
+  radarrInstanceKeys = mkInstanceApiKeys "radarr";
+  sonarrInstanceKeys = mkInstanceApiKeys "sonarr";
+  allInstanceKeys = radarrInstanceKeys ++ sonarrInstanceKeys;
 in {
   config = mkIf cfg.enable {
     # Create per-service API key groups
     users.groups = mkMerge (
-      builtins.map
-      (serviceName: mkIf cfg.${serviceName}.enable {"${serviceName}-api" = {};})
-      servicesWithApiKeys
+      (builtins.map
+        (serviceName: mkIf cfg.${serviceName}.enable {"${serviceName}-api" = {};})
+        servicesWithApiKeys)
+      ++ (builtins.map
+        (inst: {"${inst.serviceName}-api" = {};})
+        allInstanceKeys)
     );
 
     systemd.services = mkMerge (
-      # Create API key extractors for enabled services
-      builtins.map
-      (serviceName: mkIf cfg.${serviceName}.enable {"${serviceName}-api-key" = mkApiKeyExtractor serviceName;})
-      servicesWithApiKeys
+      # Create API key extractors for enabled base services
+      (builtins.map
+        (serviceName: mkIf cfg.${serviceName}.enable {
+          "${serviceName}-api-key" = mkApiKeyExtractor serviceName serviceCfgFile.${serviceName} printServiceApiKey.${serviceName};
+        })
+        servicesWithApiKeys)
+      # Create API key extractors for instances
+      ++ (builtins.map
+        (inst: {
+          "${inst.serviceName}-api-key" = mkApiKeyExtractor inst.serviceName inst.cfgFilePath inst.printScript;
+        })
+        allInstanceKeys)
     );
 
     # Create the api-keys directory

--- a/nixarr/radarr/default.nix
+++ b/nixarr/radarr/default.nix
@@ -7,8 +7,94 @@
 with lib; let
   cfg = config.nixarr.radarr;
   globals = config.util-nixarr.globals;
-  port = 7878;
   nixarr = config.nixarr;
+  defaultPort = 7878;
+
+  additionalInstancesRaw =
+    mapAttrsToList (
+      name: instanceCfg: instanceCfg // {__name = name;}
+    )
+    cfg.instances;
+
+  normalizeInstance = index: inst: let
+    name = inst.__name;
+    computedPort =
+      if inst.port != null
+      then inst.port
+      else cfg.port + index;
+    computedPackage =
+      if inst.package != null
+      then inst.package
+      else cfg.package;
+    computedVpnEnable =
+      if inst.vpn.enable != null
+      then inst.vpn.enable
+      else cfg.vpn.enable;
+    computedOpenFirewall =
+      if inst.openFirewall != null
+      then inst.openFirewall
+      else !computedVpnEnable;
+    computedStateDir =
+      if inst.stateDir != null
+      then inst.stateDir
+      else "${cfg.stateDir}-${name}";
+    computedLibrarySubDir =
+      if inst.librarySubDir != null
+      then inst.librarySubDir
+      else "${cfg.librarySubDir}-${name}";
+  in {
+    key = name;
+    serviceName = "radarr-${name}";
+    enable = inst.enable;
+    package = computedPackage;
+    port = computedPort;
+    stateDir = computedStateDir;
+    librarySubDir = computedLibrarySubDir;
+    vpnEnable = computedVpnEnable;
+    openFirewall = computedOpenFirewall;
+  };
+
+  additionalInstances = imap1 normalizeInstance additionalInstancesRaw;
+
+  baseInstance = {
+    key = "default";
+    serviceName = "radarr";
+    enable = cfg.enable;
+    package = cfg.package;
+    port = cfg.port;
+    stateDir = cfg.stateDir;
+    librarySubDir = cfg.librarySubDir;
+    vpnEnable = cfg.vpn.enable;
+    openFirewall = cfg.openFirewall;
+  };
+
+  allInstances = [baseInstance] ++ additionalInstances;
+
+  enabledInstances = filter (instance: instance.enable) allInstances;
+
+  vpnInstances =
+    filter (
+      instance: instance.enable && instance.vpnEnable
+    )
+    allInstances;
+
+  openFirewallInstances =
+    filter (
+      instance: instance.enable && instance.openFirewall
+    )
+    allInstances;
+
+  anyEnabled = enabledInstances != [];
+
+  mediaLibraryDir = "${nixarr.mediaDir}/library";
+
+  mediaSubDirs = unique (
+    map (instance: "${mediaLibraryDir}/${instance.librarySubDir}") enabledInstances
+  );
+
+  stateDirs = unique (map (instance: instance.stateDir) enabledInstances);
+
+  ports = map (instance: instance.port) enabledInstances;
 in {
   options.nixarr.radarr = {
     enable = mkOption {
@@ -24,7 +110,7 @@ in {
 
     port = mkOption {
       type = types.port;
-      default = port;
+      default = defaultPort;
       description = "Port for Radarr to use.";
     };
 
@@ -47,6 +133,15 @@ in {
       '';
     };
 
+    librarySubDir = mkOption {
+      type = types.str;
+      default = "movies";
+      example = "movies-uhd";
+      description = ''
+        Subdirectory under `${nixarr.mediaDir}/library` that Radarr manages.
+      '';
+    };
+
     openFirewall = mkOption {
       type = types.bool;
       defaultText = literalExpression ''!nixarr.radarr.vpn.enable'';
@@ -65,22 +160,95 @@ in {
         Route Radarr traffic through the VPN.
       '';
     };
+
+    instances = mkOption {
+      type = types.attrsOf (types.submodule ({name, ...}: {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether to enable this Radarr instance.";
+          };
+
+          package = mkOption {
+            type = types.nullOr types.package;
+            default = null;
+            description = "Package to use for this Radarr instance.";
+          };
+
+          port = mkOption {
+            type = types.nullOr types.port;
+            default = null;
+            description = ''
+              Port for this Radarr instance. If unset, one will be assigned
+              automatically based on `nixarr.radarr.port`.
+            '';
+          };
+
+          stateDir = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = ''
+              Override the state directory for this instance. Defaults to
+              `"''${nixarr.stateDir}/radarr-${name}"`.
+            '';
+          };
+
+          librarySubDir = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              Override the media library subdirectory for this instance.
+              Defaults to `"''${cfg.librarySubDir}-${name}"`.
+            '';
+          };
+
+          openFirewall = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Whether to open the firewall for this instance. Defaults to the
+              inverse of the resolved VPN setting.
+            '';
+          };
+
+          vpn.enable = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Route traffic for this instance through the VPN. Defaults to
+              `nixarr.radarr.vpn.enable`.
+            '';
+          };
+        };
+      }));
+      default = {};
+      example = literalExpression ''
+        {
+          "4k" = {
+            port = 7879;
+            librarySubDir = "movies-4k";
+          };
+          kids.port = 7880;
+        }
+      '';
+      description = ''
+        Additional Radarr instances keyed by a name that is appended to the
+        service name (e.g. `radarr-4k`).
+      '';
+    };
   };
 
-  config = mkIf (nixarr.enable && cfg.enable) {
+  config = mkIf (nixarr.enable && anyEnabled) {
     assertions = [
       {
-        assertion = cfg.vpn.enable -> nixarr.vpn.enable;
-        message = ''
-          The nixarr.radarr.vpn.enable option requires the
-          nixarr.vpn.enable option to be set, but it was not.
-        '';
+        assertion = (vpnInstances == []) || nixarr.vpn.enable;
+        message = "All Radarr instances that enable VPN require nixarr.vpn.enable.";
       }
-    ];
-
-    systemd.tmpfiles.rules = [
-      "d '${nixarr.mediaDir}/library'        0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/movies' 0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      {
+        assertion = length ports == length (unique ports);
+        message = "Each Radarr instance must use a unique port.";
+      }
     ];
 
     users = {
@@ -92,52 +260,101 @@ in {
       };
     };
 
-    services.radarr = {
-      enable = cfg.enable;
-      package = cfg.package;
-      user = globals.radarr.user;
-      group = globals.radarr.group;
-      settings.server.port = cfg.port;
-      openFirewall = cfg.openFirewall;
-      dataDir = cfg.stateDir;
+    systemd.tmpfiles.rules =
+      [
+        "d '${mediaLibraryDir}' 0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      ]
+      ++ map (
+        dir: "d '${dir}' 0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      )
+      mediaSubDirs
+      ++ map (
+        dir: "d '${dir}' 0700 ${globals.radarr.user} root - -"
+      )
+      stateDirs;
+
+    networking.firewall = mkIf (openFirewallInstances != []) {
+      allowedTCPPorts = map (instance: instance.port) openFirewallInstances;
     };
 
-    # Enable and specify VPN namespace to confine service in.
-    systemd.services.radarr.vpnConfinement = mkIf cfg.vpn.enable {
-      enable = true;
-      vpnNamespace = "wg";
+    systemd.services = mkMerge (
+      (map (
+          instance: {
+            ${instance.serviceName} = {
+              description =
+                "Radarr"
+                + (
+                  if instance.serviceName != "radarr"
+                  then " (${instance.key})"
+                  else ""
+                );
+              after = ["network.target"];
+              wantedBy = ["multi-user.target"];
+              environment.RADARR__SERVER__PORT = builtins.toString instance.port;
+              serviceConfig = {
+                Type = "simple";
+                User = globals.radarr.user;
+                Group = globals.radarr.group;
+                ExecStart = "${lib.getExe instance.package} -nobrowser -data=${lib.escapeShellArg instance.stateDir}";
+                Restart = "on-failure";
+              };
+            };
+          }
+        )
+        enabledInstances)
+      ++ (map (
+          instance:
+            mkIf instance.vpnEnable {
+              ${instance.serviceName}.vpnConfinement = {
+                enable = true;
+                vpnNamespace = "wg";
+              };
+            }
+        )
+        enabledInstances)
+    );
+
+    vpnNamespaces.wg = mkIf (vpnInstances != []) {
+      portMappings =
+        map (
+          instance: {
+            from = instance.port;
+            to = instance.port;
+          }
+        )
+        vpnInstances;
     };
 
-    # Port mappings
-    vpnNamespaces.wg = mkIf cfg.vpn.enable {
-      portMappings = [
-        {
-          from = cfg.port;
-          to = cfg.port;
-        }
-      ];
-    };
-
-    services.nginx = mkIf cfg.vpn.enable {
+    services.nginx = mkIf (vpnInstances != []) {
       enable = true;
 
       recommendedTlsSettings = true;
       recommendedOptimisation = true;
       recommendedGzipSettings = true;
 
-      virtualHosts."127.0.0.1:${builtins.toString cfg.port}" = {
-        listen = [
-          {
-            addr = "0.0.0.0";
-            port = cfg.port;
+      virtualHosts = listToAttrs (
+        map (
+          instance: let
+            portString = builtins.toString instance.port;
+          in {
+            name = "127.0.0.1:${portString}";
+            value = {
+              listen = [
+                {
+                  addr = "0.0.0.0";
+                  port = instance.port;
+                }
+              ];
+              locations."/" = {
+                recommendedProxySettings = true;
+                proxyWebsockets = true;
+                proxyPass = "http://192.168.15.1:${portString}";
+              };
+            };
           }
-        ];
-        locations."/" = {
-          recommendedProxySettings = true;
-          proxyWebsockets = true;
-          proxyPass = "http://192.168.15.1:${builtins.toString cfg.port}";
-        };
-      };
+        )
+        vpnInstances
+      );
     };
   };
 }

--- a/nixarr/radarr/default.nix
+++ b/nixarr/radarr/default.nix
@@ -70,17 +70,17 @@ with lib; let
 
   allInstances = [baseInstance] ++ additionalInstances;
 
-  enabledInstances = filter (instance: instance.enable) allInstances;
+  enabledInstances = filter (instance: cfg.enable && instance.enable) allInstances;
 
   vpnInstances =
     filter (
-      instance: instance.enable && instance.vpnEnable
+      instance: cfg.enable && instance.enable && instance.vpnEnable
     )
     allInstances;
 
   openFirewallInstances =
     filter (
-      instance: instance.enable && instance.openFirewall
+      instance: cfg.enable && instance.enable && instance.openFirewall
     )
     allInstances;
 

--- a/nixarr/recyclarr/default.nix
+++ b/nixarr/recyclarr/default.nix
@@ -68,6 +68,29 @@ with lib; let
     if cfg.configFile != null
     then cfg.configFile
     else generatedConfigFile;
+
+  # Collect enabled instances for radarr and sonarr
+  enabledInstanceNames = service:
+    builtins.attrNames (filterAttrs (_: inst: inst.enable) nixarr.${service}.instances);
+
+  # Convert instance name to env var suffix: "anime" -> "ANIME", "my-4k" -> "MY_4K"
+  toEnvName = name:
+    builtins.replaceStrings ["-"] ["_"] (lib.toUpper name);
+
+  radarrInstances = enabledInstanceNames "radarr";
+  sonarrInstances = enabledInstanceNames "sonarr";
+
+  instanceServiceDeps = service: names:
+    concatMap (name: ["${service}-${name}.service" "${service}-${name}-api-key.service"]) names;
+
+  instanceEnvLines = service: names:
+    concatMapStringsSep "" (name: ''
+      printf '${lib.toUpper service}_${toEnvName name}_API_KEY=' >> '${cfg.stateDir}/env'
+      cat '${nixarr.stateDir}/api-keys/${service}-${name}.key' >> '${cfg.stateDir}/env'
+    '') names;
+
+  instanceApiGroups = service: names:
+    map (name: "${service}-${name}-api") names;
 in {
   options.nixarr.recyclarr = {
     enable = mkOption {
@@ -105,7 +128,10 @@ in {
 
         The API keys for Radarr and Sonarr can be referenced in the config
         file using the `RADARR_API_KEY` and `SONARR_API_KEY` environment
-        variables (with macro `!env_var`).
+        variables (with macro `!env_var`). For additional instances, env vars
+        are named `RADARR_<NAME>_API_KEY` / `SONARR_<NAME>_API_KEY` where
+        `<NAME>` is the uppercased instance name with hyphens replaced by
+        underscores (e.g. `RADARR_ANIME_API_KEY`).
 
         Note: You cannot set both `configFile` and `configuration` options.
       '';
@@ -172,7 +198,8 @@ in {
         see the [official configuration reference](https://recyclarr.dev/wiki/yaml/config-reference/).
 
         The API keys for Radarr and Sonarr can be referenced using the `RADARR_API_KEY` and `SONARR_API_KEY`
-        environment variables (with the string "!env_var RADARR_API_KEY").
+        environment variables (with the string "!env_var RADARR_API_KEY"). For additional instances, env vars
+        are named `RADARR_<NAME>_API_KEY` / `SONARR_<NAME>_API_KEY` (e.g. `RADARR_ANIME_API_KEY`).
 
         Note: You cannot set both `configFile` and `configuration` options.
       '';
@@ -211,7 +238,9 @@ in {
         uid = globals.uids.${globals.recyclarr.user};
         extraGroups =
           (optional nixarr.radarr.enable "radarr-api")
-          ++ (optional nixarr.sonarr.enable "sonarr-api");
+          ++ (optional nixarr.sonarr.enable "sonarr-api")
+          ++ (instanceApiGroups "radarr" radarrInstances)
+          ++ (instanceApiGroups "sonarr" sonarrInstances);
       };
     };
 
@@ -227,10 +256,14 @@ in {
       before = ["recyclarr.service"];
       requires =
         (optionals nixarr.radarr.enable ["radarr.service" "radarr-api-key.service"])
-        ++ (optionals nixarr.sonarr.enable ["sonarr.service" "sonarr-api-key.service"]);
+        ++ (optionals nixarr.sonarr.enable ["sonarr.service" "sonarr-api-key.service"])
+        ++ (instanceServiceDeps "radarr" radarrInstances)
+        ++ (instanceServiceDeps "sonarr" sonarrInstances);
       after =
         (optionals nixarr.radarr.enable ["radarr.service" "radarr-api-key.service"])
-        ++ (optionals nixarr.sonarr.enable ["sonarr.service" "sonarr-api-key.service"]);
+        ++ (optionals nixarr.sonarr.enable ["sonarr.service" "sonarr-api-key.service"])
+        ++ (instanceServiceDeps "radarr" radarrInstances)
+        ++ (instanceServiceDeps "sonarr" sonarrInstances);
 
       serviceConfig = {
         Type = "oneshot";
@@ -248,6 +281,8 @@ in {
             printf SONARR_API_KEY= >> '${cfg.stateDir}/env'
             cat '${nixarr.stateDir}/api-keys/sonarr.key' >> '${cfg.stateDir}/env'
           ''}
+          ${instanceEnvLines "radarr" radarrInstances}
+          ${instanceEnvLines "sonarr" sonarrInstances}
         '';
       };
     };

--- a/nixarr/sonarr/default.nix
+++ b/nixarr/sonarr/default.nix
@@ -69,17 +69,17 @@ with lib; let
 
   allInstances = [baseInstance] ++ additionalInstances;
 
-  enabledInstances = filter (instance: instance.enable) allInstances;
+  enabledInstances = filter (instance: cfg.enable && instance.enable) allInstances;
 
   vpnInstances =
     filter (
-      instance: instance.enable && instance.vpnEnable
+      instance: cfg.enable && instance.enable && instance.vpnEnable
     )
     allInstances;
 
   openFirewallInstances =
     filter (
-      instance: instance.enable && instance.openFirewall
+      instance: cfg.enable && instance.enable && instance.openFirewall
     )
     allInstances;
 

--- a/nixarr/sonarr/default.nix
+++ b/nixarr/sonarr/default.nix
@@ -7,8 +7,93 @@
 with lib; let
   cfg = config.nixarr.sonarr;
   globals = config.util-nixarr.globals;
-  defaultPort = 8989;
   nixarr = config.nixarr;
+  defaultPort = 8989;
+
+  additionalInstancesRaw = mapAttrsToList (
+    name: instanceCfg: instanceCfg // {__name = name;}
+  )
+  cfg.instances;
+
+  normalizeInstance = index: inst: let
+    name = inst.__name;
+    computedPort =
+      if inst.port != null
+      then inst.port
+      else cfg.port + index;
+    computedPackage =
+      if inst.package != null
+      then inst.package
+      else cfg.package;
+    computedVpnEnable =
+      if inst.vpn.enable != null
+      then inst.vpn.enable
+      else cfg.vpn.enable;
+    computedOpenFirewall =
+      if inst.openFirewall != null
+      then inst.openFirewall
+      else !computedVpnEnable;
+    computedStateDir =
+      if inst.stateDir != null
+      then inst.stateDir
+      else "${cfg.stateDir}-${name}";
+    computedLibrarySubDir =
+      if inst.librarySubDir != null
+      then inst.librarySubDir
+      else "${cfg.librarySubDir}-${name}";
+  in {
+    key = name;
+    serviceName = "sonarr-${name}";
+    enable = inst.enable;
+    package = computedPackage;
+    port = computedPort;
+    stateDir = computedStateDir;
+    librarySubDir = computedLibrarySubDir;
+    vpnEnable = computedVpnEnable;
+    openFirewall = computedOpenFirewall;
+  };
+
+  additionalInstances = imap1 normalizeInstance additionalInstancesRaw;
+
+  baseInstance = {
+    key = "default";
+    serviceName = "sonarr";
+    enable = cfg.enable;
+    package = cfg.package;
+    port = cfg.port;
+    stateDir = cfg.stateDir;
+    librarySubDir = cfg.librarySubDir;
+    vpnEnable = cfg.vpn.enable;
+    openFirewall = cfg.openFirewall;
+  };
+
+  allInstances = [baseInstance] ++ additionalInstances;
+
+  enabledInstances = filter (instance: instance.enable) allInstances;
+
+  vpnInstances =
+    filter (
+      instance: instance.enable && instance.vpnEnable
+    )
+    allInstances;
+
+  openFirewallInstances =
+    filter (
+      instance: instance.enable && instance.openFirewall
+    )
+    allInstances;
+
+  anyEnabled = enabledInstances != [];
+
+  mediaLibraryDir = "${nixarr.mediaDir}/library";
+
+  mediaSubDirs = unique (
+    map (instance: "${mediaLibraryDir}/${instance.librarySubDir}") enabledInstances
+  );
+
+  stateDirs = unique (map (instance: instance.stateDir) enabledInstances);
+
+  ports = map (instance: instance.port) enabledInstances;
 in {
   options.nixarr.sonarr = {
     enable = mkOption {
@@ -25,6 +110,7 @@ in {
     port = mkOption {
       type = types.port;
       default = defaultPort;
+      example = defaultPort;
       description = "Port for Sonarr to use.";
     };
 
@@ -47,6 +133,15 @@ in {
       '';
     };
 
+    librarySubDir = mkOption {
+      type = types.str;
+      default = "shows";
+      example = "shows-uhd";
+      description = ''
+        Subdirectory under `${nixarr.mediaDir}/library` that Sonarr manages.
+      '';
+    };
+
     openFirewall = mkOption {
       type = types.bool;
       defaultText = literalExpression ''!nixarr.sonarr.vpn.enable'';
@@ -65,16 +160,94 @@ in {
         Route Sonarr traffic through the VPN.
       '';
     };
+
+    instances = mkOption {
+      type = types.attrsOf (types.submodule ({name, ...}: {
+        options = {
+          enable = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Whether to enable this Sonarr instance.";
+          };
+
+          package = mkOption {
+            type = types.nullOr types.package;
+            default = null;
+            description = "Package to use for this Sonarr instance.";
+          };
+
+          port = mkOption {
+            type = types.nullOr types.port;
+            default = null;
+            description = ''
+              Port for this Sonarr instance. If unset, one will be assigned
+              automatically based on `nixarr.sonarr.port`.
+            '';
+          };
+
+          stateDir = mkOption {
+            type = types.nullOr types.path;
+            default = null;
+            description = ''
+              Override the state directory for this instance. Defaults to
+              `"''${nixarr.stateDir}/sonarr-${name}"`.
+            '';
+          };
+
+          librarySubDir = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = ''
+              Override the media library subdirectory for this instance.
+              Defaults to `"''${cfg.librarySubDir}-${name}"`.
+            '';
+          };
+
+          openFirewall = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Whether to open the firewall for this instance. Defaults to the
+              inverse of the resolved VPN setting.
+            '';
+          };
+
+          vpn.enable = mkOption {
+            type = types.nullOr types.bool;
+            default = null;
+            description = ''
+              Route traffic for this instance through the VPN. Defaults to
+              `nixarr.sonarr.vpn.enable`.
+            '';
+          };
+        };
+      }));
+      default = {};
+      example = literalExpression ''
+        {
+          "4k" = {
+            port = 8990;
+            librarySubDir = "shows-4k";
+          };
+          anime.port = 8991;
+        }
+      '';
+      description = ''
+        Additional Sonarr instances keyed by a name that is appended to the
+        service name (e.g. `sonarr-anime`).
+      '';
+    };
   };
 
-  config = mkIf (nixarr.enable && cfg.enable) {
+  config = mkIf (nixarr.enable && anyEnabled) {
     assertions = [
       {
-        assertion = cfg.vpn.enable -> nixarr.vpn.enable;
-        message = ''
-          The nixarr.sonarr.vpn.enable option requires the
-          nixarr.vpn.enable option to be set, but it was not.
-        '';
+        assertion = (vpnInstances == []) || nixarr.vpn.enable;
+        message = "All Sonarr instances that enable VPN require nixarr.vpn.enable.";
+      }
+      {
+        assertion = length ports == length (unique ports);
+        message = "Each Sonarr instance must use a unique port.";
       }
     ];
 
@@ -87,57 +260,101 @@ in {
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${nixarr.mediaDir}/library'        0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/shows'  0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-    ];
+    systemd.tmpfiles.rules =
+      [
+        "d '${mediaLibraryDir}' 0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      ]
+      ++ map (
+        dir: "d '${dir}' 0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      )
+      mediaSubDirs
+      ++ map (
+        dir: "d '${dir}' 0700 ${globals.sonarr.user} root - -"
+      )
+      stateDirs;
 
-    services.sonarr = {
-      enable = cfg.enable;
-      package = cfg.package;
-      user = globals.sonarr.user;
-      group = globals.sonarr.group;
-      settings.server.port = cfg.port;
-      openFirewall = cfg.openFirewall;
-      dataDir = cfg.stateDir;
+    networking.firewall = mkIf (openFirewallInstances != []) {
+      allowedTCPPorts = map (instance: instance.port) openFirewallInstances;
     };
 
-    # Enable and specify VPN namespace to confine service in.
-    systemd.services.sonarr.vpnConfinement = mkIf cfg.vpn.enable {
-      enable = true;
-      vpnNamespace = "wg";
+    systemd.services = mkMerge (
+      (map (
+          instance: {
+            ${instance.serviceName} = {
+              description =
+                "Sonarr"
+                + (
+                  if instance.serviceName != "sonarr"
+                  then " (${instance.key})"
+                  else ""
+                );
+              after = ["network.target"];
+              wantedBy = ["multi-user.target"];
+              environment.SONARR__SERVER__PORT = builtins.toString instance.port;
+              serviceConfig = {
+                Type = "simple";
+                User = globals.sonarr.user;
+                Group = globals.sonarr.group;
+                ExecStart = "${lib.getExe instance.package} -nobrowser -data=${lib.escapeShellArg instance.stateDir}";
+                Restart = "on-failure";
+              };
+            };
+          }
+        )
+        enabledInstances)
+      ++ (map (
+          instance:
+            mkIf instance.vpnEnable {
+              ${instance.serviceName}.vpnConfinement = {
+                enable = true;
+                vpnNamespace = "wg";
+              };
+            }
+        )
+        enabledInstances)
+    );
+
+    vpnNamespaces.wg = mkIf (vpnInstances != []) {
+      portMappings =
+        map (
+          instance: {
+            from = instance.port;
+            to = instance.port;
+          }
+        )
+        vpnInstances;
     };
 
-    # Port mappings
-    vpnNamespaces.wg = mkIf cfg.vpn.enable {
-      portMappings = [
-        {
-          from = cfg.port;
-          to = cfg.port;
-        }
-      ];
-    };
-
-    services.nginx = mkIf cfg.vpn.enable {
+    services.nginx = mkIf (vpnInstances != []) {
       enable = true;
 
       recommendedTlsSettings = true;
       recommendedOptimisation = true;
       recommendedGzipSettings = true;
 
-      virtualHosts."127.0.0.1:${builtins.toString cfg.port}" = {
-        listen = [
-          {
-            addr = "0.0.0.0";
-            port = cfg.port;
+      virtualHosts = listToAttrs (
+        map (
+          instance: let
+            portString = builtins.toString instance.port;
+          in {
+            name = "127.0.0.1:${portString}";
+            value = {
+              listen = [
+                {
+                  addr = "0.0.0.0";
+                  port = instance.port;
+                }
+              ];
+              locations."/" = {
+                recommendedProxySettings = true;
+                proxyWebsockets = true;
+                proxyPass = "http://192.168.15.1:${portString}";
+              };
+            };
           }
-        ];
-        locations."/" = {
-          recommendedProxySettings = true;
-          proxyWebsockets = true;
-          proxyPass = "http://192.168.15.1:${builtins.toString cfg.port}";
-        };
-      };
+        )
+        vpnInstances
+      );
     };
   };
 }


### PR DESCRIPTION
Here is the work, its not super clean but I can make changes if the feature is desired.

Works by adding as many instances as you want in a `instance` field. Anything added in there is extra and the default instance is seperate. For each instance a new library folder is also created.

```nix
nixarr = {
  sonarr = {
    enable = true;
    instances = {
      "<name1>".enable = true;
      "<name2>".enable = true;
    };
  };
  radarr = {
    enable = true;
    instances = {
      "<name1>".enable = true;
      "<name2>".enable = true;
    };
  };
};
```

Example with three sonarr and three radarr instances.

Closes #93