### PR TITLE
fix: allow strings in recyclarr yaml type

### DIFF
--- a/nixarr/recyclarr/default.nix
+++ b/nixarr/recyclarr/default.nix
@@ -17,7 +17,7 @@ with lib; let
       (builtins.map (
           # this is yq for "for all the scalers, if they match this regex, do a regex substitution and set the tag"
           x: ''
-            with((.. | select(kind == "scalar") | select(test("^!${x} .*"))); . = sub("!${x} ", "") | . tag="!${x}")
+            with((.. | select(kind == "scalar") | select(tag == "!!str") | select(test("^!${x} .*"))); . = sub("!${x} ", "") | . tag="!${x}")
           ''
         )
         preserved-tags);


### PR DESCRIPTION
Fix the recyclarr YAML format type to include `types.str` (duplicate `float` removed), so `nixarr.recyclarr.configuration` accepts string fields.

Fixes https://github.com/rasmus-kirk/nixarr/issues/104