### PR TITLE
nixarr-py: add a pyproject.toml for tool config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+# Configuration for various tools to find the nixarr-py library path
+
+[tool.ty.environment]
+extra-paths = ["./nixarr/lib/nixarr-py"]
+
+[tool.pyright]
+extraPaths = ["./nixarr/lib/nixarr-py"]
+
+[tool.mypy]
+mypy_path = "./nixarr/lib/nixarr-py"


### PR DESCRIPTION
This helps Python tooling find the `nixarr-py` project when run from the repo root directory.