### PR TITLE
fix(*arr): add UMask to systemd services for proper group permissions

### DIFF
--- a/nixarr/bazarr/default.nix
+++ b/nixarr/bazarr/default.nix
@@ -90,6 +90,9 @@ in {
         Type = "simple";
         User = globals.bazarr.user;
         Group = globals.bazarr.group;
+        # Set UMask to 0002 so directories are created with group write permission (775)
+        # This allows other services in the media group (like Jellyfin) to modify files
+        UMask = "0002";
         SyslogIdentifier = "bazarr";
         ExecStart = pkgs.writeShellScript "start-bazarr" ''
           ${pkgs.bazarr}/bin/bazarr \

--- a/nixarr/lidarr/default.nix
+++ b/nixarr/lidarr/default.nix
@@ -101,6 +101,10 @@ in {
       dataDir = cfg.stateDir;
     };
 
+    # Set UMask to 0002 so directories are created with group write permission (775)
+    # This allows other services in the media group (like Jellyfin) to modify files
+    systemd.services.lidarr.serviceConfig.UMask = "0002";
+
     # Enable and specify VPN namespace to confine service in.
     systemd.services.lidarr.vpnConfinement = mkIf cfg.vpn.enable {
       enable = true;

--- a/nixarr/radarr/default.nix
+++ b/nixarr/radarr/default.nix
@@ -103,6 +103,10 @@ in {
       dataDir = cfg.stateDir;
     };
 
+    # Set UMask to 0002 so directories are created with group write permission (775)
+    # This allows other services in the media group (like Jellyfin) to modify files
+    systemd.services.radarr.serviceConfig.UMask = "0002";
+
     # Enable and specify VPN namespace to confine service in.
     systemd.services.radarr.vpnConfinement = mkIf cfg.vpn.enable {
       enable = true;

--- a/nixarr/sonarr/default.nix
+++ b/nixarr/sonarr/default.nix
@@ -103,6 +103,10 @@ in {
       dataDir = cfg.stateDir;
     };
 
+    # Set UMask to 0002 so directories are created with group write permission (775)
+    # This allows other services in the media group (like Jellyfin) to modify files
+    systemd.services.sonarr.serviceConfig.UMask = "0002";
+
     # Enable and specify VPN namespace to confine service in.
     systemd.services.sonarr.vpnConfinement = mkIf cfg.vpn.enable {
       enable = true;


### PR DESCRIPTION
## Summary
- Add `UMask = "0002"` to radarr, sonarr, lidarr, and bazarr systemd service configs
- This ensures directories are created with 775 permissions instead of 755
- Allows other services in the media group (like Jellyfin) to modify files

## Root cause
The *arr services inherited the default umask (022), which strips the group write bit from newly created directories. Transmission already had `umask = "002"` configured (fixed in #56), but radarr/sonarr/lidarr/bazarr did not.

## Test plan
- [ ] Enable radarr and jellyfin via nixarr
- [ ] Let radarr import a movie to the library
- [ ] Verify the created directory has 775 permissions
- [ ] Verify Jellyfin can delete files in the directory

Fixes #130