### PR TITLE
fix: make Jellyfin library writeable by all users in the "media" group.

### DIFF
--- a/nixarr/jellyfin/default.nix
+++ b/nixarr/jellyfin/default.nix
@@ -155,12 +155,12 @@ in {
       "d '${cfg.stateDir}/config' 0700 ${globals.jellyfin.user} root - -"
 
       # Media Dirs
-      "d '${nixarr.mediaDir}/library'             0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/shows'       0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/movies'      0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/music'       0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/books'       0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
-      "d '${nixarr.mediaDir}/library/audiobooks'  0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      "d '${nixarr.mediaDir}/library'             2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      "d '${nixarr.mediaDir}/library/shows'       2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      "d '${nixarr.mediaDir}/library/movies'      2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      "d '${nixarr.mediaDir}/library/music'       2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      "d '${nixarr.mediaDir}/library/books'       2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
+      "d '${nixarr.mediaDir}/library/audiobooks'  2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
     ];
 
     # Always prioritise Jellyfin IO


### PR DESCRIPTION
This PR fixes the issue that disallows users of the `media` group to have write (and thus delete) permissions.

This does not affect any file permissions of existing systems, as it only changes the permissions that are set when the library directories are created for the first time. Users with an existing installation can run `sudo chmod -R 2775 /path/to/jellyfin/library` to actively change the library path and everything in it to have the correct permissions.