### PR TITLE
Add hash for Jellyfin 10.11.6

### DIFF
--- a/nixarr/lib/nixarr-py/python-deps.nix
+++ b/nixarr/lib/nixarr-py/python-deps.nix
@@ -151,6 +151,7 @@
           "10.11.3" = "sha256-KBMlCE55z2QZyXF5rpQWpR7Lklol0Z149uZu3e6GumU=";
           "10.11.4" = "sha256-xTwN7KR68Gb6+XGE6C3lT1Gg6Mq8MF7T73PfwgV/mYo=";
           "10.11.5" = "sha256-SgsOEDRGMU2uEO9+i2jouxJCqnejqDx9zSMep6rwXOQ=";
+          "10.11.6" = "sha256-0g9qN5GV5g7tY/5Qew5VjpIopPgfvwuu5z4vXYz8Q1A=";
         })."${jellyfin.version}";
     };
     openapi-config = writeTextFile {


### PR DESCRIPTION
 ## Summary
  - Adds the nixarr-py dependency hash for Jellyfin version 10.11.6