### PR TITLE
fix: use cfg.package instead of pkgs.bazarr in the bazarr module

### DIFF
--- a/nixarr/bazarr/default.nix
+++ b/nixarr/bazarr/default.nix
@@ -93,7 +93,7 @@ in {
         Group = globals.bazarr.group;
         SyslogIdentifier = "bazarr";
         ExecStart = pkgs.writeShellScript "start-bazarr" ''
-          ${pkgs.bazarr}/bin/bazarr \
+          ${cfg.package}/bin/bazarr \
             --config '${cfg.stateDir}' \
             --port ${toString cfg.port} \
             --no-update True


### PR DESCRIPTION
This PR fixes the issue where users cannot use a custom package for the bazarr service. Instead of hardcoding the package to be `pkgs.bazarr`, the actual `nixarr.bazarr.package` option is used now as `cfg.package`. This follows the pattern of every other module in this repo.

I tested this on my machine and it works perfectly, just as all the other modules that use `cfg.package`.