### PR TITLE
fix(qbittorrent): deep-merge extraConfig with lib.recursiveUpdate

### DIFF
--- a/nixarr/qbittorrent/default.nix
+++ b/nixarr/qbittorrent/default.nix
@@ -23,7 +23,7 @@ with lib; let
 
   # Generate qBittorrent configuration
   qbittorrentConfig =
-    {
+    lib.recursiveUpdate {
       BitTorrent = {
         # Download paths
         "Session\\DefaultSavePath" = downloadDir;
@@ -84,7 +84,7 @@ with lib; let
         "Downloads\\PreAllocation" = true; # Pre-allocate disk space
       };
     }
-    // cfg.extraConfig;
+    cfg.extraConfig;
 in {
   options.nixarr.qbittorrent = {
     enable = mkOption {


### PR DESCRIPTION
## Summary

- Fix `extraConfig` shallow merge (`//`) silently replacing entire generated config sections
- Use `lib.recursiveUpdate` to deep-merge user-provided `extraConfig` with generated defaults

## Problem

The `qbittorrentConfig` definition uses the Nix `//` operator to merge `cfg.extraConfig` with the generated defaults:

```nix
qbittorrentConfig = {
  BitTorrent = { ... };
  Preferences = { ... };
} // cfg.extraConfig;
```

The `//` operator performs a **shallow merge** — it replaces values at the top level. This means if a user provides:

```nix
nixarr.qbittorrent.extraConfig.BitTorrent."Session\\MaxActiveDownloads" = 10;
```

The entire generated `BitTorrent` section is replaced, **silently dropping** all defaults:
- `Session\DHTEnabled`, `Session\PeXEnabled`, `Session\LSDEnabled` (controlled by `privateTrackers.disableDhtPex`)
- `Session\Port`, `Session\Encryption`, `Session\AnonymousModeEnabled`
- All download path settings, performance tuning, and category configuration

The same issue applies to the `Preferences` section — any `extraConfig.Preferences` key silently replaces all WebUI, download, and proxy settings.

## Fix

Replace `//` with `lib.recursiveUpdate` so that user-provided keys are deep-merged into the generated defaults rather than replacing them:

```nix
qbittorrentConfig = lib.recursiveUpdate {
  BitTorrent = { ... };
  Preferences = { ... };
} cfg.extraConfig;
```

This allows users to override individual settings within a section without losing the rest of the generated configuration.

## Test plan

- [ ] Verify that `extraConfig = {}` (default) produces the same config as before
- [ ] Verify that `extraConfig.BitTorrent."Session\\MaxActiveDownloads" = 20;` only overrides that single key while preserving all other `BitTorrent` defaults
- [ ] Verify that `privateTrackers.disableDhtPex = true` still works correctly when combined with `extraConfig.BitTorrent` overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)