### PR TITLE
feat: add Anchorr service and comprehensive test suite

### DIFF
--- a/anchorr-pkg
+++ b/anchorr-pkg
@@ -1,1 +1,0 @@
-/nix/store/w4bwrzv8vm2m0p266zssv60w998fl32c-anchorr-1.4.0

--- a/anchorr-pkg
+++ b/anchorr-pkg
@@ -1,0 +1,1 @@
+/nix/store/w4bwrzv8vm2m0p266zssv60w998fl32c-anchorr-1.4.0

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,9 @@
         simple-test = pkgs.callPackage ./tests/simple-test.nix {
           inherit (self) nixosModules;
         };
+        anchorr-test = pkgs.callPackage ./tests/anchorr-test.nix {
+          inherit (self) nixosModules;
+        };
         # vpn-confinement-test = pkgs.callPackage ./tests/vpn-confinement-test.nix {
         #   inherit (self) nixosModules;
         # };

--- a/nixarr/anchorr/default.nix
+++ b/nixarr/anchorr/default.nix
@@ -1,0 +1,416 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.nixarr.anchorr;
+  globals = config.util-nixarr.globals;
+  nixarr = config.nixarr;
+  port = 8282;
+
+  settingsFormat = pkgs.formats.json {};
+  generatedConfigFile = settingsFormat.generate "anchorr-config.json" cfg.configuration;
+
+  effectiveConfigFile =
+    if cfg.configFile != null
+    then cfg.configFile
+    else generatedConfigFile;
+in {
+  options.nixarr.anchorr = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether or not to enable the Anchorr service.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.callPackage ./package.nix {};
+      defaultText = literalExpression "pkgs.callPackage ./package.nix {}";
+      description = "The package used for the Anchorr service.";
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "${nixarr.stateDir}/anchorr";
+      defaultText = literalExpression ''"''${nixarr.stateDir}/anchorr"'';
+      example = "/nixarr/.state/anchorr";
+      description = ''
+        The location of the state directory for the Anchorr service.
+
+        > **Warning:** Setting this to any path, where the subpath is not
+        > owned by root, will fail! For example:
+        >
+        > ```nix
+        >   stateDir = /home/user/nixarr/.state/anchorr
+        > ```
+        >
+        > Is not supported, because `/home/user` is owned by `user`.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = port;
+      example = 12345;
+      description = "Anchorr web-UI port.";
+    };
+
+    discordTokenFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/data/.secret/anchorr/discord-token";
+      description = "Path to a file containing the Discord bot token.";
+    };
+
+    tmdbApiKeyFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/data/.secret/anchorr/tmdb-api-key";
+      description = "Path to a file containing the TMDB API key.";
+    };
+
+    jellyseerr = {
+      url = mkOption {
+        type = types.str;
+        default = "http://localhost:5055";
+        example = "http://192.168.1.50:5055";
+        description = "URL of the Jellyseerr instance.";
+      };
+      apiKeyFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/data/.secret/anchorr/jellyseerr-api-key";
+        description = "Path to a file containing the Jellyseerr API key.";
+      };
+    };
+
+    environmentFiles = mkOption {
+      type = types.listOf types.path;
+      default = [];
+      example = literalExpression "[ config.sops.secrets.anchorr_env.path ]";
+      description = "List of environment files (e.g., from sops-nix) containing secrets.";
+    };
+
+    secretsFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/data/.secret/anchorr/env";
+      description = "Environment file containing secrets like DISCORD_TOKEN, TMDB_API_KEY, etc. This is a legacy option, prefer environmentFiles.";
+    };
+
+    configFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Path to a custom config.json for Anchorr.";
+    };
+
+    configuration = mkOption {
+      type = settingsFormat.type;
+      default = {};
+      example = literalExpression ''
+        {
+          discord = {
+            bot_id = "123456789";
+            guild_id = "987654321";
+          };
+        }
+      '';
+      description = "Anchorr configuration as a Nix attribute set. Generated as config.json.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      defaultText = literalExpression ''!nixarr.anchorr.vpn.enable'';
+      default = !cfg.vpn.enable;
+      example = true;
+      description = "Open firewall for Anchorr";
+    };
+
+    vpn.enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        **Required options:** [`nixarr.vpn.enable`](#nixarr.vpn.enable)
+
+        **Conflicting options:** [`nixarr.anchorr.expose.https.enable`](#nixarr.anchorr.expose.https.enable)
+
+        Route Anchorr traffic through the VPN.
+      '';
+    };
+
+    expose = {
+      https = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          example = true;
+          description = ''
+            **Required options:**
+
+            - [`nixarr.anchorr.expose.https.acmeMail`](#nixarr.anchorr.expose.https.acmemail)
+            - [`nixarr.anchorr.expose.https.domainName`](#nixarr.anchorr.expose.https.domainname)
+
+            **Conflicting options:** [`nixarr.anchorr.vpn.enable`](#nixarr.anchorr.vpn.enable)
+
+            Expose the Anchorr web service to the internet with https support,
+            allowing anyone to access it.
+
+            > **Warning:** Do _not_ enable this without setting up Anchorr
+            > authentication through localhost first!
+          '';
+        };
+
+        upnp.enable = mkEnableOption "UPNP to try to open ports 80 and 443 on your router.";
+
+        domainName = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "anchorr.example.com";
+          description = "The domain name to host Anchorr on.";
+        };
+
+        acmeMail = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "mail@example.com";
+          description = "The ACME mail required for the letsencrypt bot.";
+        };
+      };
+    };
+  };
+
+  config = mkIf (nixarr.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = cfg.vpn.enable -> nixarr.vpn.enable;
+        message = ''
+          The nixarr.anchorr.vpn.enable option requires the
+          nixarr.vpn.enable option to be set, but it was not.
+        '';
+      }
+      {
+        assertion = !(cfg.vpn.enable && cfg.expose.https.enable);
+        message = ''
+          The nixarr.anchorr.vpn.enable option conflicts with the
+          nixarr.anchorr.expose.https.enable option. You cannot set both.
+        '';
+      }
+      {
+        assertion =
+          cfg.expose.https.enable
+          -> (
+            (cfg.expose.https.domainName != null)
+            && (cfg.expose.https.acmeMail != null)
+          );
+        message = ''
+          The nixarr.anchorr.expose.https.enable option requires the
+          following options to be set, but one of them were not:
+
+          - nixarr.anchorr.expose.https.domainName
+          - nixarr.anchorr.expose.https.acmeMail
+        '';
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.stateDir}'        0750 ${globals.anchorr.user} ${globals.anchorr.group} - -"
+      "d '${cfg.stateDir}/logs'   0750 ${globals.anchorr.user} ${globals.anchorr.group} - -"
+      "d '${cfg.stateDir}/config' 0750 ${globals.anchorr.user} ${globals.anchorr.group} - -"
+    ];
+
+    systemd.services.anchorr-setup = {
+      description = "Setup Anchorr configuration and environment";
+      requiredBy = ["anchorr.service"];
+      before = ["anchorr.service"];
+      requires = optional nixarr.jellyseerr.enable "jellyseerr-api-key.service";
+      after = optional nixarr.jellyseerr.enable "jellyseerr-api-key.service";
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        UMask = "0077";
+        # Setup runs as anchorr user to have access to its own secrets
+        # (e.g. from sops-nix) which might be restricted to that user.
+        User = globals.anchorr.user;
+        Group = globals.anchorr.group;
+        ExecStart = pkgs.writeShellScript "anchorr-setup" ''
+          set -euo pipefail
+
+          # Handle config.json
+          cp '${effectiveConfigFile}' '${cfg.stateDir}/config/config.json'
+
+          # Generate environment file with secrets from single files
+          ENV_FILE='${cfg.stateDir}/env'
+          echo "# Generated by nixarr-anchorr-setup" > "$ENV_FILE"
+
+          ${optionalString (cfg.discordTokenFile != null) ''
+            printf "DISCORD_TOKEN=" >> "$ENV_FILE"
+            cat '${cfg.discordTokenFile}' >> "$ENV_FILE"
+            echo "" >> "$ENV_FILE"
+          ''}
+
+          ${optionalString (cfg.tmdbApiKeyFile != null) ''
+            printf "TMDB_API_KEY=" >> "$ENV_FILE"
+            cat '${cfg.tmdbApiKeyFile}' >> "$ENV_FILE"
+            echo "" >> "$ENV_FILE"
+          ''}
+
+          ${optionalString (cfg.jellyseerr.apiKeyFile != null) ''
+            printf "JELLYSEERR_API_KEY=" >> "$ENV_FILE"
+            cat '${cfg.jellyseerr.apiKeyFile}' >> "$ENV_FILE"
+            echo "" >> "$ENV_FILE"
+          ''}
+
+          ${optionalString (nixarr.jellyseerr.enable && cfg.jellyseerr.apiKeyFile == null) ''
+            if [[ -f '${nixarr.stateDir}/api-keys/jellyseerr.key' ]]; then
+              printf "JELLYSEERR_API_KEY=" >> "$ENV_FILE"
+              cat '${nixarr.stateDir}/api-keys/jellyseerr.key' >> "$ENV_FILE"
+              echo "" >> "$ENV_FILE"
+            fi
+          ''}
+
+          chmod 600 "$ENV_FILE"
+        '';
+      };
+    };
+
+    systemd.services.anchorr = {
+      description = "Anchorr, a Discord bot for media requests";
+      after = ["network.target" "anchorr-setup.service"];
+      requires = ["anchorr-setup.service"];
+      wantedBy = ["multi-user.target"];
+
+      environment = {
+        JELLYSEERR_URL = cfg.jellyseerr.url;
+        WEBHOOK_PORT = toString cfg.port;
+      };
+
+      serviceConfig = {
+        Type = "exec";
+        StateDirectory = "anchorr";
+        WorkingDirectory = cfg.stateDir;
+        ExecStartPre = [
+          (pkgs.writeShellScript "anchorr-pre-start" ''
+            mkdir -p '${cfg.stateDir}'
+            touch '${cfg.stateDir}/env'
+          '')
+        ];
+        EnvironmentFile =
+          ["-${cfg.stateDir}/env"]
+          ++ (map (f: "-${toString f}") cfg.environmentFiles)
+          ++ (optional (cfg.secretsFile != null) "-${toString cfg.secretsFile}");
+        DynamicUser = false;
+        User = globals.anchorr.user;
+        Group = globals.anchorr.group;
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "on-failure";
+
+        # Security
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        NoNewPrivileges = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        PrivateMounts = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [cfg.stateDir];
+      };
+    };
+
+    users = {
+      groups.${globals.anchorr.group}.gid = globals.gids.${globals.anchorr.group};
+      users.${globals.anchorr.user} = {
+        isSystemUser = true;
+        group = globals.anchorr.group;
+        uid = globals.uids.${globals.anchorr.user};
+        extraGroups = optional nixarr.jellyseerr.enable "jellyseerr-api";
+      };
+    };
+
+    networking.firewall = mkMerge [
+      (mkIf cfg.expose.https.enable {
+        allowedTCPPorts = [80 443];
+      })
+      (mkIf cfg.openFirewall {
+        allowedTCPPorts = [cfg.port];
+      })
+    ];
+
+    util-nixarr.upnp = mkIf cfg.expose.https.upnp.enable {
+      enable = true;
+      openTcpPorts = [80 443];
+    };
+
+    services.nginx = mkMerge [
+      (mkIf (cfg.expose.https.enable || cfg.vpn.enable) {
+        enable = true;
+
+        recommendedTlsSettings = true;
+        recommendedOptimisation = true;
+        recommendedGzipSettings = true;
+      })
+      (mkIf cfg.expose.https.enable {
+        virtualHosts."${builtins.replaceStrings ["\n"] [""] cfg.expose.https.domainName}" = {
+          enableACME = true;
+          forceSSL = true;
+          locations."/" = {
+            recommendedProxySettings = true;
+            proxyWebsockets = true;
+            proxyPass = "http://127.0.0.1:${builtins.toString cfg.port}";
+          };
+        };
+      })
+      (mkIf cfg.vpn.enable {
+        virtualHosts."127.0.0.1:${builtins.toString cfg.port}" = {
+          listen = [
+            {
+              addr = "0.0.0.0";
+              port = cfg.port;
+            }
+          ];
+          locations."/" = {
+            recommendedProxySettings = true;
+            proxyWebsockets = true;
+            proxyPass = "http://192.168.15.1:${builtins.toString cfg.port}";
+          };
+        };
+      })
+    ];
+
+    security.acme = mkIf cfg.expose.https.enable {
+      acceptTerms = true;
+      defaults.email = cfg.expose.https.acmeMail;
+    };
+
+    # Enable and specify VPN namespace to confine service in.
+    systemd.services.anchorr.vpnConfinement = mkIf cfg.vpn.enable {
+      enable = true;
+      vpnNamespace = "wg";
+    };
+
+    # Port mappings
+    vpnNamespaces.wg = mkIf cfg.vpn.enable {
+      portMappings = [
+        {
+          from = cfg.port;
+          to = cfg.port;
+        }
+      ];
+    };
+  };
+}

--- a/nixarr/anchorr/package.nix
+++ b/nixarr/anchorr/package.nix
@@ -1,0 +1,47 @@
+{
+  bash,
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+}:
+buildNpmPackage rec {
+  pname = "anchorr";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "nairdahh";
+    repo = "Anchorr";
+    rev = "v${version}";
+    hash = "sha256-8xlablHtBtJuOgm/7hl4XWmyWYD+fE7L9igRECErDX4=";
+  };
+
+  npmDepsHash = "sha256-YXPLHloxRci8PIDB5g+myxP36JFhQ2M54hQC86+1mMY=";
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/anchorr"
+    cp -r . "$out/lib/anchorr/"
+
+    mkdir -p "$out/bin"
+    cat > "$out/bin/anchorr" <<EOF
+    #!${lib.getExe bash}
+    exec ${lib.getExe nodejs} "$out/lib/anchorr/app.js" "\$@"
+    EOF
+    chmod +x "$out/bin/anchorr"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Discord bot for media requests via Jellyseerr and notifications for Jellyfin";
+    homepage = "https://github.com/nairdahh/Anchorr";
+    license = licenses.gpl3Only;
+    maintainers = [];
+    platforms = platforms.linux;
+    mainProgram = "anchorr";
+  };
+}

--- a/nixarr/default.nix
+++ b/nixarr/default.nix
@@ -9,6 +9,7 @@ with lib; let
   globals = config.util-nixarr.globals;
 in {
   imports = [
+    ./anchorr
     ./audiobookshelf
     ./autobrr
     ./bazarr
@@ -59,6 +60,7 @@ in {
 
         The following services are supported:
 
+        - [Anchorr](#nixarr.anchorr.enable)
         - [Audiobookshelf](#nixarr.audiobookshelf.enable)
         - [Autobrr](#nixarr.autobrr.enable)
         - [Bazarr](#nixarr.bazarr.enable)

--- a/nixarr/nixarr-command/default.nix
+++ b/nixarr/nixarr-command/default.nix
@@ -56,6 +56,10 @@ with lib; let
         chown -R ${globals.audiobookshelf.user}:root "${nixarr.audiobookshelf.stateDir}"
         find "${nixarr.audiobookshelf.stateDir}" \( -type d -exec chmod 0700 {} + -true \) -o \( -exec chmod 0600 {} + \)
       ''}
+        ${strings.optionalString nixarr.anchorr.enable ''
+        chown -R ${globals.anchorr.user}:root "${nixarr.anchorr.stateDir}"
+        find "${nixarr.anchorr.stateDir}" \( -type d -exec chmod 0700 {} + -true \) -o \( -exec chmod 0600 {} + \)
+      ''}
         ${strings.optionalString nixarr.transmission.enable ''
         chown -R ${globals.transmission.user}:${globals.transmission.group} "${nixarr.mediaDir}/torrents"
         chown -R ${globals.transmission.user}:${globals.cross-seed.group} "${nixarr.transmission.stateDir}"
@@ -195,8 +199,8 @@ with lib; let
 
         echo "Wiping all nixarr users and groups from /etc/passwd and /etc/group..."
 
-        sed -i -E '/^(audiobookshelf|autobrr|bazarr|cross-seed|jellyfin|jellyseerr|lidarr|plex|prowlarr|radarr|readarr|recyclarr|sabnzbd|sonarr|streamer|torrenter|transmission|usenet|whisparr|komgarr)/d' /etc/passwd
-        sed -i -E '/^(autobrr|cross-seed|jellyseerr|media|prowlarr|recyclarr|sabnzbd|streamer|torrenter|transmission|usenet)/d' /etc/group
+        sed -i -E '/^(anchorr|audiobookshelf|autobrr|bazarr|cross-seed|jellyfin|jellyseerr|lidarr|plex|prowlarr|radarr|readarr|recyclarr|sabnzbd|sonarr|streamer|torrenter|transmission|usenet|whisparr|komgarr)/d' /etc/passwd
+        sed -i -E '/^(anchorr|autobrr|cross-seed|jellyseerr|media|prowlarr|recyclarr|sabnzbd|streamer|torrenter|transmission|usenet)/d' /etc/group
 
         echo ""
         echo "Done, please rebuild your configuration to get back the users and groups. This time, they will have the correct permissions."

--- a/tests/anchorr-test.nix
+++ b/tests/anchorr-test.nix
@@ -1,0 +1,71 @@
+{
+  pkgs,
+  nixosModules,
+  lib ? pkgs.lib,
+}:
+pkgs.testers.nixosTest {
+  name = "anchorr-test";
+
+  nodes.machine = {
+    config,
+    pkgs,
+    ...
+  }: {
+    imports = [nixosModules.default];
+
+    networking.firewall.enable = false;
+
+    nixarr = {
+      enable = true;
+      jellyseerr.enable = true;
+
+      anchorr = {
+        enable = true;
+        discordTokenFile = pkgs.writeText "discord-token" "test-discord-token";
+        tmdbApiKeyFile = pkgs.writeText "tmdb-api-key" "test-tmdb-api-key";
+        configuration = {
+          discord = {
+            bot_id = "123456789";
+            guild_id = "987654321";
+          };
+        };
+      };
+    };
+
+    # Mock jellyseerr API key extraction since we don't want to run full jellyseerr
+    systemd.services.jellyseerr-api-key = {
+      serviceConfig.ExecStart = lib.mkForce (pkgs.writeShellScript "mock-jellyseerr-api-key" ''
+        mkdir -p /data/.state/nixarr/api-keys
+        echo "mock-jellyseerr-key" > /data/.state/nixarr/api-keys/jellyseerr.key
+        chown root:jellyseerr-api /data/.state/nixarr/api-keys/jellyseerr.key
+        chmod 640 /data/.state/nixarr/api-keys/jellyseerr.key
+      '');
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("anchorr-setup.service")
+    machine.wait_for_unit("anchorr.service")
+
+    # Check that anchorr and its setup service are active/completed
+    machine.succeed("systemctl is-active anchorr")
+
+    # Verify config.json was generated and copied correctly
+    machine.succeed("grep '123456789' /data/.state/nixarr/anchorr/config/config.json")
+    machine.succeed("grep '987654321' /data/.state/nixarr/anchorr/config/config.json")
+
+    # Verify env file was generated with secrets
+    machine.succeed("grep 'DISCORD_TOKEN=test-discord-token' /data/.state/nixarr/anchorr/env")
+    machine.succeed("grep 'TMDB_API_KEY=test-tmdb-api-key' /data/.state/nixarr/anchorr/env")
+
+    # Verify Jellyseerr API key was pulled from the extracted key file
+    machine.succeed("grep 'JELLYSEERR_API_KEY=mock-jellyseerr-key' /data/.state/nixarr/anchorr/env")
+
+    # Verify permissions of the env file (should be 600 and owned by anchorr)
+    # Note: stat -c %a might return 600
+    machine.succeed("stat -c '%a %U:%G' /data/.state/nixarr/anchorr/env | grep '600 anchorr:anchorr'")
+
+    print("\n=== Anchorr Test Completed Successfully ===")
+  '';
+}

--- a/tests/simple-test.nix
+++ b/tests/simple-test.nix
@@ -15,6 +15,9 @@ pkgs.testers.nixosTest {
 
     networking.firewall.enable = false;
 
+    virtualisation.memorySize = 4096;
+    virtualisation.diskSize = 8192;
+
     nixarr = {
       enable = true;
 
@@ -39,6 +42,7 @@ pkgs.testers.nixosTest {
       prowlarr.enable = true;
       whisparr.enable = true;
       komga.enable = true;
+      anchorr.enable = true;
 
       # recyclarr = {
       #   enable = true;
@@ -112,6 +116,7 @@ pkgs.testers.nixosTest {
     machine.succeed("systemctl is-active sabnzbd")
     machine.succeed("systemctl is-active lidarr")
     machine.succeed("systemctl is-active prowlarr")
+    machine.succeed("systemctl is-active anchorr")
     # machine.succeed("systemctl is-active recyclarr")
 
     print("\n=== Nixarr Simple Test Completed ===")

--- a/util/globals/default.nix
+++ b/util/globals/default.nix
@@ -23,6 +23,7 @@ in {
       plex = 193;
       jellyfin = 146;
       audiobookshelf = 156;
+      anchorr = 185;
       autobrr = 188;
       bazarr = 232;
       lidarr = 306;
@@ -42,6 +43,7 @@ in {
       stash = 69;
     };
     gids = {
+      anchorr = 185;
       autobrr = 188;
       # Removed 2025-10-29
       # cross-seed = 183;
@@ -55,6 +57,10 @@ in {
     audiobookshelf = {
       user = "audiobookshelf";
       group = globals.libraryOwner.group;
+    };
+    anchorr = {
+      user = "anchorr";
+      group = "anchorr";
     };
     autobrr = {
       user = "autobrr";


### PR DESCRIPTION
### Description
This PR introduces **Anchorr** as a module within Nixarr. Anchorr is a Discord bot that facilitates media requests via Jellyseerr and provides notifications for Jellyfin.

### Key Changes
- **New Service Module**: Added `nixarr/anchorr` with support for automated configuration generation (`config.json`), environment secret management, and systemd service orchestration.
- **Package Definition**: Included a project-local `package.nix` for Anchorr.
- **Secret Orchestration**: Implemented the `anchorr-setup` service pattern to cleanly handle Discord tokens, TMDB API keys, and dynamic extraction of Jellyseerr API keys.
- **Globals Integration**: Updated `util/globals` with consistent UID/GID and group ownership for Anchorr.
- **VPN & Expose Support**: Standardized VPN confinement and Nginx reverse-proxy options consistent with existing Nixarr services.

### Testing Strategy
The changes have been rigorously verified through:
1. **Dedicated Regression Test (`tests/anchorr-test.nix`)**: Specifically verifies the `anchorr-setup` logic, ensuring secrets are correctly injected and file permissions are strictly enforced (`600` for secret files).
2. **Integration Test (`tests/simple-test.nix`)**: Included Anchorr in the full-stack integration test to ensure no conflicts with the other 15+ services.
3. **Stability Improvements**: Fixed existing test suite instability by increasing VM memory (4096MB) and disk size (8192MB) to satisfy Jellyfin's minimum requirements and prevent OOM kernel panics during full-suite testing.

### Scope
This PR covers the implementation of the Anchorr service, its necessary package definitions, global configuration updates, and a comprehensive suite of NixOS VM tests.

----
Would love if someone would help me kick the tires if there's even interest.