### PR TITLE
feat: add Sickbeard MP4 Automator (SMA) module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,9 +19,26 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "sickbeard-mp4-automator": "sickbeard-mp4-automator",
         "treefmt-nix": "treefmt-nix",
         "vpnconfinement": "vpnconfinement",
         "website-builder": "website-builder"
+      }
+    },
+    "sickbeard-mp4-automator": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771841168,
+        "narHash": "sha256-pSCBAJ2pPfnNfQCvkC8Qy6IshK3J8oACRbFJolor3AU=",
+        "owner": "mdhiggins",
+        "repo": "sickbeard_mp4_automator",
+        "rev": "e3db46613bba5724ab298b64a9214f6f6ae863b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mdhiggins",
+        "repo": "sickbeard_mp4_automator",
+        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,11 @@
 
     website-builder.url = "github:rasmus-kirk/website-builder";
     website-builder.inputs.nixpkgs.follows = "nixpkgs";
+
+    sickbeard-mp4-automator = {
+      url = "github:mdhiggins/sickbeard_mp4_automator";
+      flake = false;
+    };
   };
 
   outputs = {
@@ -18,6 +23,7 @@
     treefmt-nix,
     vpnconfinement,
     website-builder,
+    sickbeard-mp4-automator,
     self,
     ...
   } @ inputs: let
@@ -44,6 +50,7 @@
     nixosModules.default.imports = [
       ./nixarr
       vpnconfinement.nixosModules.default
+      {_module.args.sickbeard-mp4-automator-src = sickbeard-mp4-automator;}
     ];
 
     # Add tests attribute to the flake outputs

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,9 @@
       bazarr-sync-test = pkgs.callPackage ./tests/bazarr-sync-test.nix {
         inherit (self) nixosModules;
       };
+      sma-test = pkgs.callPackage ./tests/sma-test.nix {
+        inherit (self) nixosModules;
+      };
       jellyfin-api-test = pkgs.callPackage ./tests/jellyfin-api-test.nix {
         inherit (self) nixosModules;
       };

--- a/nixarr/default.nix
+++ b/nixarr/default.nix
@@ -31,6 +31,7 @@ in {
     ./sonarr
     ./transmission
     ./whisparr
+    ./sma
     ./monitoring
     ../util
   ];
@@ -77,6 +78,7 @@ in {
         - [SABnzbd](#nixarr.sabnzbd.enable)
         - [Sonarr](#nixarr.sonarr.enable)
         - [Transmission](#nixarr.transmission.enable)
+        - [SMA](#nixarr.sma.enable) (Sickbeard MP4 Automator)
 
         Remember to read the options!
       '';

--- a/nixarr/sma/default.nix
+++ b/nixarr/sma/default.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  sickbeard-mp4-automator-src,
   ...
 }:
 with lib; let
@@ -17,6 +18,7 @@ with lib; let
       then pkgs.ffmpeg-full
       else pkgs.ffmpeg;
     logDir = smaLogDir;
+    src = sickbeard-mp4-automator-src;
   };
 
   smaStateDir = "${nixarr.stateDir}/sma";

--- a/nixarr/sma/default.nix
+++ b/nixarr/sma/default.nix
@@ -1,0 +1,527 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.nixarr.sma;
+  nixarr = config.nixarr;
+  globals = config.util-nixarr.globals;
+
+  smaLogDir = "${smaStateDir}/logs";
+
+  smaPackage = pkgs.callPackage ./package.nix {
+    ffmpeg =
+      if cfg.hardware-acceleration == "nvenc"
+      then pkgs.ffmpeg-full
+      else pkgs.ffmpeg;
+    logDir = smaLogDir;
+  };
+
+  smaStateDir = "${nixarr.stateDir}/sma";
+  smaConfigPath = "${smaStateDir}/autoProcess.ini";
+
+  # Wrapper scripts that set the config path via SMA_CONFIG env var
+  sonarrScript = pkgs.writeShellScript "sma-postsonarr" ''
+    export SMA_CONFIG="${smaConfigPath}"
+    exec ${smaPackage}/bin/sma-postsonarr
+  '';
+
+  radarrScript = pkgs.writeShellScript "sma-postradarr" ''
+    export SMA_CONFIG="${smaConfigPath}"
+    exec ${smaPackage}/bin/sma-postradarr
+  '';
+
+  # Config template with __SONARR_API_KEY__ and __RADARR_API_KEY__ placeholders
+  # These get substituted at runtime by sma-setup.service
+  autoProcessIniTemplate = pkgs.writeText "autoProcess.ini.template" ''
+    [Converter]
+    ffmpeg = ffmpeg
+    ffprobe = ffprobe
+    threads = ${toString cfg.threads}
+    hwaccels = ${cfg.hardware-acceleration}
+    hwaccel-decoders = ${concatStringsSep ", " cfg.hwaccel-decoders}
+    hwoutputfmt = nv12
+    output-directory = ${cfg.output-directory}
+    output-format = ${cfg.output-format}
+    output-extension = ${cfg.output-extension}
+    temp-extension =
+    minimum-size = ${toString cfg.minimum-size}
+    ignored-extensions = nfo, ds_store
+    copy-to =
+    move-to =
+    delete-original = ${boolToString cfg.delete-original}
+    sort-streams = true
+    process-same-extensions = ${boolToString cfg.process-same-extensions}
+    force-convert = false
+    post-process = false
+    preopts =
+    postopts =
+    preset =
+
+    [Permissions]
+    chmod = 0664
+    uid = -1
+    gid = -1
+
+    [Metadata]
+    download-artwork = poster
+    relocate-moov = true
+    tag = ${boolToString cfg.tag-metadata}
+    tag-language = en
+
+    [Video]
+    codec = ${concatStringsSep ", " cfg.video-codecs}
+    max-bitrate = ${toString cfg.video-max-bitrate}
+    crf = ${toString cfg.video-crf}
+    crf-profiles =
+    max-width = ${toString cfg.video-max-width}
+    profile =
+    max-level =
+    pix-fmt =
+
+    [HDR]
+    codec =
+    pix-fmt =
+    space = bt2020nc
+    transfer = smpte2084
+    primaries = bt2020
+    preset =
+    filter =
+    force-filter = false
+    profile =
+
+    [Audio]
+    codec = ${concatStringsSep ", " cfg.audio-codecs}
+    languages = ${concatStringsSep ", " cfg.audio-languages}
+    default-language = ${cfg.audio-default-language}
+    first-stream-of-language = false
+    allow-language-relax = true
+    channel-bitrate = 128
+    max-bitrate = 0
+    max-channels = 0
+    prefer-more-channels = true
+    default-more-channels = true
+    copy-original = ${boolToString cfg.audio-copy-original}
+    aac-adtstoasc = false
+    ignore-truehd = mp4
+    ignored-dispositions =
+    unique-dispositions = false
+
+    [Audio.Sorting]
+    sorting =
+
+    [Universal Audio]
+    codec = aac
+    channel-bitrate = 128
+    first-stream-only = false
+    move-after = false
+    filter =
+
+    [Audio.ChannelFilters]
+
+    [Subtitle]
+    codec = ${concatStringsSep ", " cfg.subtitle-codecs}
+    codec-image-based =
+    languages = ${concatStringsSep ", " cfg.subtitle-languages}
+    default-language = ${cfg.subtitle-default-language}
+    first-stream-of-language = false
+    encoding =
+    burn-subtitles = false
+    download-subtitles = ${boolToString cfg.download-subtitles}
+    embed-subs = true
+    embed-image-subs = false
+    embed-only-internal-subs = false
+    attachment-codec =
+    remove-bitstream-subs = false
+    ignored-dispositions =
+    unique-dispositions = false
+
+    [Subtitle.Sorting]
+    sorting =
+
+    [Subtitle.CleanIt]
+    config =
+
+    [Subtitle.FFSubsync]
+    enabled = false
+
+    [Subtitle.Subliminal]
+    ${optionalString cfg.download-subtitles "providers = opensubtitles, podnapisi"}
+
+    [Sonarr]
+    host = localhost
+    port = ${toString nixarr.sonarr.port}
+    apikey = __SONARR_API_KEY__
+    ssl = false
+    webroot =
+    force-rename = false
+    force-rescan = true
+    in-progress-check = true
+
+    [Radarr]
+    host = localhost
+    port = ${toString nixarr.radarr.port}
+    apikey = __RADARR_API_KEY__
+    ssl = false
+    webroot =
+    force-rename = false
+    force-rescan = true
+    in-progress-check = true
+
+    [Plex]
+    enabled = false
+  '';
+
+  # Script to register SMA as a Connect notification in an *arr service
+  mkRegisterScript = {
+    service,
+    scriptPath,
+  }: let
+    curl = getExe pkgs.curl;
+    jq = getExe pkgs.jq;
+    port = toString nixarr.${service}.port;
+    apiKeyFile = "${nixarr.stateDir}/secrets/${service}.api-key";
+  in
+    pkgs.writeShellScript "sma-register-${service}" ''
+      set -euo pipefail
+      API_KEY=$(cat '${apiKeyFile}')
+      BASE_URL="http://127.0.0.1:${port}/api/v3"
+
+      # Check if SMA connect already exists
+      EXISTING=$(${curl} -s -f \
+        -H "X-Api-Key: $API_KEY" \
+        "$BASE_URL/notification" | ${jq} -r '[.[] | select(.name == "SMA") | .id] | first // empty')
+
+      PAYLOAD=$(${jq} -n '{
+        name: "SMA",
+        implementation: "CustomScript",
+        configContract: "CustomScriptSettings",
+        onDownload: true,
+        onUpgrade: true,
+        supportsOnDownload: true,
+        supportsOnUpgrade: true,
+        fields: [
+          {name: "path", value: $script_path},
+          {name: "arguments", value: ""}
+        ]
+      }' --arg script_path "${scriptPath}")
+
+      if [ -n "$EXISTING" ]; then
+        echo "Updating existing SMA connect (id=$EXISTING) in ${service}"
+        ${curl} -s -f -X PUT \
+          -H "X-Api-Key: $API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$(echo "$PAYLOAD" | ${jq} --argjson id "$EXISTING" '. + {id: $id}')" \
+          "$BASE_URL/notification/$EXISTING" > /dev/null
+      else
+        echo "Creating SMA connect in ${service}"
+        ${curl} -s -f -X POST \
+          -H "X-Api-Key: $API_KEY" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" \
+          "$BASE_URL/notification" > /dev/null
+      fi
+      echo "SMA connect configured in ${service}"
+    '';
+
+  # Services that must be ready before SMA setup can run
+  requiredApiServices =
+    (optional cfg.sonarr.enable "sonarr-api.service")
+    ++ (optional cfg.radarr.enable "radarr-api.service");
+in {
+  options.nixarr.sma = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether or not to enable the Sickbeard MP4 Automator (SMA) integration.
+        SMA automatically converts video files downloaded by Sonarr/Radarr to a
+        standardized format using FFmpeg.
+
+        When enabled, SMA is registered as a Custom Script connect notification
+        in Sonarr and/or Radarr, which triggers automatic conversion on
+        download and upgrade events.
+      '';
+    };
+
+    hardware-acceleration = mkOption {
+      type = types.enum ["" "nvenc" "vaapi" "qsv"];
+      default = "";
+      example = "nvenc";
+      description = ''
+        Hardware acceleration method to use for encoding.
+        Set to "" for software encoding.
+      '';
+    };
+
+    hwaccel-decoders = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = ["h264_cuvid" "hevc_cuvid"];
+      description = "Hardware-accelerated decoders to use.";
+    };
+
+    threads = mkOption {
+      type = types.int;
+      default = 0;
+      description = "Number of FFmpeg threads. 0 = auto.";
+    };
+
+    output-directory = mkOption {
+      type = types.str;
+      default = "";
+      description = "Output directory for converted files. Empty = convert in-place.";
+    };
+
+    output-format = mkOption {
+      type = types.enum ["mp4" "mkv" "mov"];
+      default = "mkv";
+      description = "Output container format.";
+    };
+
+    output-extension = mkOption {
+      type = types.str;
+      default = "mkv";
+      description = "Output file extension.";
+    };
+
+    minimum-size = mkOption {
+      type = types.int;
+      default = 0;
+      description = "Minimum file size in bytes to process. 0 = no minimum.";
+    };
+
+    delete-original = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Delete the original file after conversion.";
+    };
+
+    process-same-extensions = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Process files even if they already have the target extension.";
+    };
+
+    tag-metadata = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Tag files with metadata from TMDB.";
+    };
+
+    video-codecs = mkOption {
+      type = types.listOf types.str;
+      default = ["h264" "hevc"];
+      example = ["hevc" "av1"];
+      description = ''
+        Accepted video codecs. Files with other codecs will be re-encoded
+        to the first codec in the list.
+      '';
+    };
+
+    video-max-bitrate = mkOption {
+      type = types.int;
+      default = 0;
+      description = "Maximum video bitrate in Kbps. 0 = no limit.";
+    };
+
+    video-crf = mkOption {
+      type = types.int;
+      default = 23;
+      description = "Constant Rate Factor for video encoding. Lower = better quality, bigger files.";
+    };
+
+    video-max-width = mkOption {
+      type = types.int;
+      default = 0;
+      description = "Maximum video width. 0 = no limit. Set to 1920 to cap at 1080p.";
+    };
+
+    audio-codecs = mkOption {
+      type = types.listOf types.str;
+      default = ["aac" "ac3" "eac3"];
+      description = "Accepted audio codecs.";
+    };
+
+    audio-languages = mkOption {
+      type = types.listOf types.str;
+      default = ["eng"];
+      description = "Audio languages to keep.";
+    };
+
+    audio-default-language = mkOption {
+      type = types.str;
+      default = "eng";
+      description = "Default audio language.";
+    };
+
+    audio-copy-original = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Keep a copy of the original audio stream alongside the converted one.";
+    };
+
+    subtitle-codecs = mkOption {
+      type = types.listOf types.str;
+      default = ["srt" "ass" "subrip" "mov_text"];
+      description = "Accepted subtitle codecs.";
+    };
+
+    subtitle-languages = mkOption {
+      type = types.listOf types.str;
+      default = ["eng"];
+      description = "Subtitle languages to keep.";
+    };
+
+    subtitle-default-language = mkOption {
+      type = types.str;
+      default = "eng";
+      description = "Default subtitle language.";
+    };
+
+    download-subtitles = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Download subtitles using subliminal.";
+    };
+
+    configFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to a custom autoProcess.ini file. If set, this overrides
+        all other SMA configuration options. You are responsible for
+        including the correct API keys in the file.
+      '';
+    };
+
+    sonarr.enable = mkOption {
+      type = types.bool;
+      default = true;
+      example = false;
+      description = "Enable SMA post-import processing for Sonarr.";
+    };
+
+    radarr.enable = mkOption {
+      type = types.bool;
+      default = true;
+      example = false;
+      description = "Enable SMA post-import processing for Radarr.";
+    };
+  };
+
+  config = mkIf (nixarr.enable && cfg.enable) {
+    assertions = [
+      {
+        assertion = cfg.sonarr.enable -> nixarr.sonarr.enable;
+        message = "nixarr.sma.sonarr.enable requires nixarr.sonarr.enable to be true.";
+      }
+      {
+        assertion = cfg.radarr.enable -> nixarr.radarr.enable;
+        message = "nixarr.sma.radarr.enable requires nixarr.radarr.enable to be true.";
+      }
+      {
+        assertion = cfg.sonarr.enable || cfg.radarr.enable;
+        message = "nixarr.sma requires at least one of sonarr or radarr to be enabled.";
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d '${smaStateDir}' 0775 root ${globals.libraryOwner.group} - -"
+      "d '${smaLogDir}' 0775 root ${globals.libraryOwner.group} - -"
+      "C '${smaLogDir}/logging.ini' 0664 root ${globals.libraryOwner.group} - ${smaPackage}/lib/sma/logging.ini.default"
+    ];
+
+    # CLI tool for manual conversions
+    environment.systemPackages = let
+      smaWithConfig = pkgs.writeShellScriptBin "sma" ''
+        exec ${smaPackage}/bin/sma-manual -c "${smaConfigPath}" "$@"
+      '';
+    in [smaWithConfig];
+
+    # Setup service: generates autoProcess.ini with real API keys
+    systemd.services.sma-setup = mkIf (cfg.configFile == null) {
+      description = "Generate SMA autoProcess.ini with API keys";
+      after = requiredApiServices;
+      requires = requiredApiServices;
+      wantedBy =
+        (optional cfg.sonarr.enable "sonarr.service")
+        ++ (optional cfg.radarr.enable "radarr.service");
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        UMask = "0022";
+        ExecStart = let
+          sed = getExe pkgs.gnused;
+          sonarrKeyFile = "${nixarr.stateDir}/secrets/sonarr.api-key";
+          radarrKeyFile = "${nixarr.stateDir}/secrets/radarr.api-key";
+        in
+          pkgs.writeShellScript "sma-setup" ''
+            set -euo pipefail
+            cp '${autoProcessIniTemplate}' '${smaConfigPath}'
+            chmod 644 '${smaConfigPath}'
+
+            ${optionalString cfg.sonarr.enable ''
+              SONARR_KEY=$(cat '${sonarrKeyFile}')
+              ${sed} -i "s/__SONARR_API_KEY__/$SONARR_KEY/" '${smaConfigPath}'
+            ''}
+            ${optionalString cfg.radarr.enable ''
+              RADARR_KEY=$(cat '${radarrKeyFile}')
+              ${sed} -i "s/__RADARR_API_KEY__/$RADARR_KEY/" '${smaConfigPath}'
+            ''}
+            echo "SMA config generated at ${smaConfigPath}"
+          '';
+      };
+    };
+
+    # If custom config file is provided, just symlink it
+    systemd.services.sma-setup-custom = mkIf (cfg.configFile != null) {
+      description = "Symlink custom SMA config";
+      wantedBy = ["multi-user.target"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = pkgs.writeShellScript "sma-setup-custom" ''
+          ln -sf '${cfg.configFile}' '${smaConfigPath}'
+        '';
+      };
+    };
+
+    # Register SMA as a Connect notification in Sonarr
+    systemd.services.sma-register-sonarr = mkIf cfg.sonarr.enable {
+      description = "Register SMA as a Connect notification in Sonarr";
+      after = ["sonarr-api.service" "sma-setup.service"];
+      requires = ["sonarr-api.service"];
+      wants = ["sma-setup.service"];
+      wantedBy = ["sonarr.service"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = mkRegisterScript {
+          service = "sonarr";
+          scriptPath = toString sonarrScript;
+        };
+      };
+    };
+
+    # Register SMA as a Connect notification in Radarr
+    systemd.services.sma-register-radarr = mkIf cfg.radarr.enable {
+      description = "Register SMA as a Connect notification in Radarr";
+      after = ["radarr-api.service" "sma-setup.service"];
+      requires = ["radarr-api.service"];
+      wants = ["sma-setup.service"];
+      wantedBy = ["radarr.service"];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = mkRegisterScript {
+          service = "radarr";
+          scriptPath = toString radarrScript;
+        };
+      };
+    };
+  };
+}

--- a/nixarr/sma/package.nix
+++ b/nixarr/sma/package.nix
@@ -2,10 +2,10 @@
   lib,
   python3Packages,
   python3,
-  fetchFromGitHub,
   ffmpeg,
   makeWrapper,
   logDir ? "/tmp/sma",
+  src,
 }:
 let
   deps = with python3Packages; [
@@ -28,15 +28,10 @@ let
 in
   python3Packages.buildPythonApplication rec {
     pname = "sickbeard-mp4-automator";
-    version = "0-unstable-2025-04-12";
+    version = "0-unstable-${src.lastModifiedDate or "unknown"}";
     format = "other";
 
-    src = fetchFromGitHub {
-      owner = "mdhiggins";
-      repo = "sickbeard_mp4_automator";
-      rev = "e3db46613bba5724ab298b64a9214f6f6ae863b1";
-      hash = "sha256-pSCBAJ2pPfnNfQCvkC8Qy6IshK3J8oACRbFJolor3AU=";
-    };
+    inherit src;
 
     nativeBuildInputs = [makeWrapper];
 

--- a/nixarr/sma/package.nix
+++ b/nixarr/sma/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  python3Packages,
+  python3,
+  fetchFromGitHub,
+  ffmpeg,
+  makeWrapper,
+  logDir ? "/tmp/sma",
+}:
+let
+  deps = with python3Packages; [
+    requests
+    idna
+    requests-cache
+    babelfish
+    tmdbsimple
+    mutagen
+    guessit
+    subliminal
+    python-dateutil
+    stevedore
+    cleanit
+    plexapi
+    setuptools
+  ];
+
+  pythonPath = python3Packages.makePythonPath deps;
+in
+  python3Packages.buildPythonApplication rec {
+    pname = "sickbeard-mp4-automator";
+    version = "0-unstable-2025-04-12";
+    format = "other";
+
+    src = fetchFromGitHub {
+      owner = "mdhiggins";
+      repo = "sickbeard_mp4_automator";
+      rev = "e3db46613bba5724ab298b64a9214f6f6ae863b1";
+      hash = "sha256-pSCBAJ2pPfnNfQCvkC8Qy6IshK3J8oACRbFJolor3AU=";
+    };
+
+    nativeBuildInputs = [makeWrapper];
+
+    dontBuild = true;
+    dontCheck = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      siteDir=$out/lib/sma
+      mkdir -p $siteDir $out/bin
+
+      # Copy all source files
+      cp -r $src/autoprocess $siteDir/
+      cp -r $src/converter $siteDir/
+      cp -r $src/resources $siteDir/
+      cp -r $src/config $siteDir/
+      cp $src/manual.py $siteDir/
+      cp $src/postSonarr.py $siteDir/
+      cp $src/postRadarr.py $siteDir/
+
+      # Create __init__.py for the package and subpackages
+      touch $siteDir/__init__.py
+      for dir in autoprocess converter resources config; do
+        touch $siteDir/$dir/__init__.py
+      done
+
+      # Rewrite relative imports to absolute (sma.*)
+      for f in $(find $siteDir -name "*.py"); do
+        substituteInPlace "$f" \
+          --replace-quiet "from autoprocess" "from sma.autoprocess" \
+          --replace-quiet "from converter" "from sma.converter" \
+          --replace-quiet "from resources" "from sma.resources" \
+          --replace-quiet "import autoprocess" "import sma.autoprocess" \
+          --replace-quiet "import converter" "import sma.converter" \
+          --replace-quiet "import resources" "import sma.resources"
+      done
+
+      # Patch ffmpeg/ffprobe paths to use nix store paths
+      substituteInPlace $siteDir/resources/readsettings.py \
+        --replace-quiet "ffmpeg = os.path.join(config_path, config.get(section, 'ffmpeg'))" \
+                        "ffmpeg = '${ffmpeg}/bin/ffmpeg'" \
+        --replace-quiet "ffprobe = os.path.join(config_path, config.get(section, 'ffprobe'))" \
+                        "ffprobe = '${ffmpeg}/bin/ffprobe'"
+
+      # Patch log.py: redirect writable paths to the log dir, seed logging.ini
+      cp $src/setup/logging.ini.sample $siteDir/logging.ini.default
+      ${python3}/bin/python3 ${./patch-log.py} $siteDir/resources/log.py "${logDir}"
+
+      # Create wrapper scripts with all Python deps on PYTHONPATH
+      makeWrapper ${python3}/bin/python3 $out/bin/sma-manual \
+        --prefix PYTHONPATH : "$siteDir/..:${pythonPath}" \
+        --add-flags "$siteDir/manual.py"
+
+      makeWrapper ${python3}/bin/python3 $out/bin/sma-postsonarr \
+        --prefix PYTHONPATH : "$siteDir/..:${pythonPath}" \
+        --add-flags "$siteDir/postSonarr.py"
+
+      makeWrapper ${python3}/bin/python3 $out/bin/sma-postradarr \
+        --prefix PYTHONPATH : "$siteDir/..:${pythonPath}" \
+        --add-flags "$siteDir/postRadarr.py"
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "Automatically convert video files to a standardized format with metadata tagging";
+      homepage = "https://github.com/mdhiggins/sickbeard_mp4_automator";
+      license = licenses.mit;
+      maintainers = [];
+    };
+  }

--- a/nixarr/sma/patch-log.py
+++ b/nixarr/sma/patch-log.py
@@ -1,0 +1,38 @@
+"""Patch log.py to redirect all writable paths out of the nix store.
+
+Takes two args: <log.py path> <writable log dir>
+The log dir should be a directory writable by all SMA-invoking users (e.g. via
+group permissions on the media group).
+"""
+import sys
+
+path = sys.argv[1]
+log_dir = sys.argv[2]
+
+with open(path) as f:
+    content = f.read()
+
+# Redirect logpath from configpath (in nix store) to the provided log dir
+content = content.replace(
+    "logpath = configpath",
+    f"logpath = '{log_dir}'",
+)
+
+# Also redirect the logging.ini configfile lookup to the log dir
+content = content.replace(
+    "configfile = os.path.abspath(os.path.join(configpath, CONFIG_DEFAULT))",
+    "configfile = os.path.abspath(os.path.join(logpath, CONFIG_DEFAULT))",
+)
+
+# Before checkLoggingConfig call, seed the default logging.ini if missing
+content = content.replace(
+    "    checkLoggingConfig(configfile)\n",
+    "    if not os.path.exists(configfile):\n"
+    "        import shutil as _shutil\n"
+    "        _default = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'logging.ini.default')\n"
+    "        _shutil.copy2(_default, configfile)\n"
+    "    checkLoggingConfig(configfile)\n",
+)
+
+with open(path, "w") as f:
+    f.write(content)

--- a/tests/sma-test.nix
+++ b/tests/sma-test.nix
@@ -1,0 +1,144 @@
+{
+  pkgs,
+  nixosModules,
+}:
+pkgs.testers.nixosTest {
+  name = "sma-test";
+
+  nodes.machine = {
+    config,
+    pkgs,
+    ...
+  }: {
+    imports = [nixosModules.default];
+
+    networking.firewall.enable = false;
+
+    virtualisation.cores = 4;
+    virtualisation.memorySize = 4096;
+
+    services = {
+      sonarr.settings.auth.required = "DisabledForLocalAddresses";
+      radarr.settings.auth.required = "DisabledForLocalAddresses";
+    };
+
+    nixarr = {
+      enable = true;
+
+      transmission.enable = true;
+
+      sonarr = {
+        enable = true;
+        settings-sync.transmission.enable = true;
+      };
+
+      radarr = {
+        enable = true;
+        settings-sync.transmission.enable = true;
+      };
+
+      sma = {
+        enable = true;
+        video-codecs = ["h264" "hevc"];
+        output-format = "mkv";
+        output-extension = "mkv";
+        audio-languages = ["eng" "dan"];
+        subtitle-languages = ["eng" "dan"];
+        audio-default-language = "eng";
+        subtitle-default-language = "eng";
+      };
+    };
+  };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("multi-user.target")
+
+    # 1. Check core services are active
+    machine.succeed("systemctl is-active transmission")
+    machine.succeed("systemctl is-active sonarr")
+    machine.succeed("systemctl is-active radarr")
+
+    # 2. Wait for API key extraction
+    machine.wait_for_unit("sonarr-api.service", timeout=120)
+    machine.wait_for_unit("radarr-api.service", timeout=120)
+
+    # 3. Wait for SMA setup service (generates autoProcess.ini)
+    machine.wait_for_unit("sma-setup.service", timeout=120)
+
+    # 4. Verify autoProcess.ini exists and contains real API keys (not placeholders)
+    config_content = machine.succeed("cat /data/.state/nixarr/sma/autoProcess.ini")
+    assert "__SONARR_API_KEY__" not in config_content, "Sonarr API key placeholder was not replaced"
+    assert "__RADARR_API_KEY__" not in config_content, "Radarr API key placeholder was not replaced"
+
+    # Verify the sonarr API key in the config matches the extracted key
+    sonarr_key = machine.succeed("cat /data/.state/nixarr/secrets/sonarr.api-key").strip()
+    assert sonarr_key in config_content, "Sonarr API key not found in config"
+    assert len(sonarr_key) > 10, "Sonarr API key looks too short: " + sonarr_key
+
+    radarr_key = machine.succeed("cat /data/.state/nixarr/secrets/radarr.api-key").strip()
+    assert radarr_key in config_content, "Radarr API key not found in config"
+    assert len(radarr_key) > 10, "Radarr API key looks too short: " + radarr_key
+
+    # 5. Verify config has expected settings
+    assert "codec = h264, hevc" in config_content, "Video codecs not set correctly"
+    assert "languages = eng, dan" in config_content, "Languages not set correctly"
+    assert "output-format = mkv" in config_content, "Output format not set correctly"
+
+    print("=== autoProcess.ini verified ===")
+
+    # 6. Wait for SMA registration in sonarr and radarr
+    machine.wait_for_unit("sma-register-sonarr.service", timeout=120)
+    machine.wait_for_unit("sma-register-radarr.service", timeout=120)
+
+    # 7. Verify SMA is registered as a Connect notification in Sonarr
+    sonarr_notifications = machine.succeed(
+        f"curl -s -H 'X-Api-Key: {sonarr_key}' http://127.0.0.1:8989/api/v3/notification"
+    )
+    sonarr_notifs = json.loads(sonarr_notifications)
+    sma_sonarr = [n for n in sonarr_notifs if n["name"] == "SMA"]
+    assert len(sma_sonarr) == 1, f"Expected 1 SMA notification in Sonarr, got {len(sma_sonarr)}"
+    assert sma_sonarr[0]["implementation"] == "CustomScript", "SMA should be a CustomScript"
+    assert sma_sonarr[0]["onDownload"] is True, "SMA should trigger on download"
+    assert sma_sonarr[0]["onUpgrade"] is True, "SMA should trigger on upgrade"
+
+    print("=== SMA registered in Sonarr ===")
+
+    # 8. Verify SMA is registered as a Connect notification in Radarr
+    radarr_notifications = machine.succeed(
+        f"curl -s -H 'X-Api-Key: {radarr_key}' http://127.0.0.1:7878/api/v3/notification"
+    )
+    radarr_notifs = json.loads(radarr_notifications)
+    sma_radarr = [n for n in radarr_notifs if n["name"] == "SMA"]
+    assert len(sma_radarr) == 1, f"Expected 1 SMA notification in Radarr, got {len(sma_radarr)}"
+    assert sma_radarr[0]["implementation"] == "CustomScript", "SMA should be a CustomScript"
+    assert sma_radarr[0]["onDownload"] is True, "SMA should trigger on download"
+    assert sma_radarr[0]["onUpgrade"] is True, "SMA should trigger on upgrade"
+
+    print("=== SMA registered in Radarr ===")
+
+    # 9. Verify the sma CLI tool is available and works
+    machine.succeed("sma --help")
+
+    # 10. Verify idempotency: run registration again, should still have exactly 1
+    machine.succeed("systemctl restart sma-register-sonarr.service")
+    machine.succeed("systemctl restart sma-register-radarr.service")
+
+    sonarr_notifications = machine.succeed(
+        f"curl -s -H 'X-Api-Key: {sonarr_key}' http://127.0.0.1:8989/api/v3/notification"
+    )
+    sma_sonarr = [n for n in json.loads(sonarr_notifications) if n["name"] == "SMA"]
+    assert len(sma_sonarr) == 1, f"Idempotency failed: expected 1 SMA in Sonarr, got {len(sma_sonarr)}"
+
+    radarr_notifications = machine.succeed(
+        f"curl -s -H 'X-Api-Key: {radarr_key}' http://127.0.0.1:7878/api/v3/notification"
+    )
+    sma_radarr = [n for n in json.loads(radarr_notifications) if n["name"] == "SMA"]
+    assert len(sma_radarr) == 1, f"Idempotency failed: expected 1 SMA in Radarr, got {len(sma_radarr)}"
+
+    print("=== Idempotency verified ===")
+
+    print("\n=== SMA Test Completed Successfully ===")
+  '';
+}


### PR DESCRIPTION
## Summary

- Adds `nixarr.sma` module that integrates [sickbeard_mp4_automator](https://github.com/mdhiggins/sickbeard_mp4_automator) for automatic post-import video conversion via FFmpeg
- Packages sickbeard_mp4_automator from upstream with all Python deps resolved from nixpkgs
- Auto-registers as a Custom Script Connect notification in Sonarr/Radarr via their APIs
- Generates `autoProcess.ini` at runtime, injecting real API keys from the nixarr secrets directory
- Declarative NixOS options for video codecs, audio/subtitle languages, hardware acceleration (NVENC/VAAPI/QSV), CRF, max bitrate, etc.
- Includes `sma` CLI command for manual conversions
- Full NixOS VM test covering config generation, API registration, idempotency, and CLI availability

### Example usage

```nix
nixarr = {
  enable = true;
  sonarr.enable = true;
  radarr.enable = true;
  transmission.enable = true;

  sma = {
    enable = true;
    hardware-acceleration = "nvenc";
    hwaccel-decoders = ["h264_cuvid" "hevc_cuvid"];
    video-codecs = ["h264" "hevc"];
    output-format = "mkv";
    audio-languages = ["eng"];
    subtitle-languages = ["eng"];
  };
};
```

### Services created

| Service | Purpose |
|---------|---------|
| `sma-setup` | Generates `autoProcess.ini` with real API keys after `*-api.service` |
| `sma-register-sonarr` | Registers SMA as a Connect notification in Sonarr |
| `sma-register-radarr` | Registers SMA as a Connect notification in Radarr |

## Test plan

- [x] `nix build .#checks.x86_64-linux.sma-test` passes
- [x] Config generation verified (API key placeholders replaced)
- [x] Connect registration verified in both Sonarr and Radarr APIs
- [x] Idempotency verified (re-registration updates, doesn't duplicate)
- [x] `sma --help` CLI works
- [x] Deployed and tested on a real host (luna)