### PR TITLE
jellyseerr: rename to seerr 

### DIFF
--- a/docs/wiki/examples/example-1/index.md
+++ b/docs/wiki/examples/example-1/index.md
@@ -49,6 +49,6 @@ This example does the following:
     radarr.enable = true;
     readarr.enable = true;
     sonarr.enable = true;
-    jellyseerr.enable = true;
+    seerr.enable = true;
   };
 ```

--- a/docs/wiki/examples/example-2/index.md
+++ b/docs/wiki/examples/example-2/index.md
@@ -40,7 +40,7 @@ the following:
     prowlarr.enable = true;
     readarr.enable = true;
     lidarr.enable = true;
-    jellyseerr.enable = true;
+    seerr.enable = true;
   };
 
   # The `openssh.vpn.enable` option does not enable openssh, so we do that here:

--- a/nixarr/anchorr/default.nix
+++ b/nixarr/anchorr/default.nix
@@ -229,8 +229,8 @@ in {
       description = "Setup Anchorr configuration and environment";
       requiredBy = ["anchorr.service"];
       before = ["anchorr.service"];
-      requires = optional nixarr.jellyseerr.enable "jellyseerr-api-key.service";
-      after = optional nixarr.jellyseerr.enable "jellyseerr-api-key.service";
+      requires = optional nixarr.seerr.enable "seerr-api.service";
+      after = optional nixarr.seerr.enable "seerr-api.service";
 
       serviceConfig = {
         Type = "oneshot";
@@ -268,10 +268,10 @@ in {
             echo "" >> "$ENV_FILE"
           ''}
 
-          ${optionalString (nixarr.jellyseerr.enable && cfg.jellyseerr.apiKeyFile == null) ''
-            if [[ -f '${nixarr.stateDir}/api-keys/jellyseerr.key' ]]; then
+          ${optionalString (nixarr.seerr.enable && cfg.jellyseerr.apiKeyFile == null) ''
+            if [[ -f '${nixarr.stateDir}/secrets/seerr.api-key' ]]; then
               printf "JELLYSEERR_API_KEY=" >> "$ENV_FILE"
-              cat '${nixarr.stateDir}/api-keys/jellyseerr.key' >> "$ENV_FILE"
+              cat '${nixarr.stateDir}/secrets/seerr.api-key' >> "$ENV_FILE"
               echo "" >> "$ENV_FILE"
             fi
           ''}
@@ -338,7 +338,7 @@ in {
         isSystemUser = true;
         group = globals.anchorr.group;
         uid = globals.uids.${globals.anchorr.user};
-        extraGroups = optional nixarr.jellyseerr.enable "jellyseerr-api";
+        extraGroups = optional nixarr.seerr.enable "seerr-api";
       };
     };
 

--- a/nixarr/default.nix
+++ b/nixarr/default.nix
@@ -16,6 +16,7 @@ in {
     ./ddns
     ./jellyfin
     ./jellyseerr
+    ./seerr
     ./lib
     ./komga
     ./lidarr
@@ -66,7 +67,7 @@ in {
         - [Autobrr](#nixarr.autobrr.enable)
         - [Bazarr](#nixarr.bazarr.enable)
         - [Jellyfin](#nixarr.jellyfin.enable)
-        - [Jellyseerr](#nixarr.jellyseerr.enable)
+        - [Seerr](#nixarr.seerr.enable)
         - [Lidarr](#nixarr.lidarr.enable)
         - [Plex](#nixarr.plex.enable)
         - [Prowlarr](#nixarr.prowlarr.enable)

--- a/nixarr/jellyseerr/default.nix
+++ b/nixarr/jellyseerr/default.nix
@@ -1,0 +1,15 @@
+{lib, ...}: {
+  imports = [
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "enable"] ["nixarr" "seerr" "enable"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "package"] ["nixarr" "seerr" "package"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "stateDir"] ["nixarr" "seerr" "stateDir"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "port"] ["nixarr" "seerr" "port"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "openFirewall"] ["nixarr" "seerr" "openFirewall"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "vpn" "enable"] ["nixarr" "seerr" "vpn" "enable"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "vpn" "configureNginx"] ["nixarr" "seerr" "vpn" "configureNginx"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "expose" "https" "enable"] ["nixarr" "seerr" "expose" "https" "enable"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "expose" "https" "upnp" "enable"] ["nixarr" "seerr" "expose" "https" "upnp" "enable"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "expose" "https" "domainName"] ["nixarr" "seerr" "expose" "https" "domainName"])
+    (lib.mkRenamedOptionModule ["nixarr" "jellyseerr" "expose" "https" "acmeMail"] ["nixarr" "seerr" "expose" "https" "acmeMail"])
+  ];
+}

--- a/nixarr/lib/apis.nix
+++ b/nixarr/lib/apis.nix
@@ -26,7 +26,7 @@
   serviceCfgFile =
     {
       bazarr = "${cfg.bazarr.stateDir}/config/config.yaml";
-      jellyseerr = "${cfg.jellyseerr.stateDir}/settings.json";
+      seerr = "${cfg.seerr.stateDir}/settings.json";
       sabnzbd = "${cfg.sabnzbd.stateDir}/sabnzbd.ini";
       transmission = "${cfg.transmission.stateDir}/.config/transmission-daemon/settings.json";
     }
@@ -42,8 +42,8 @@
       bazarr = pkgs.writeShellScript "print-bazarr-api-key" ''
         ${yq} -r .auth.apikey '${serviceCfgFile.bazarr}'
       '';
-      jellyseerr = pkgs.writeShellScript "print-jellyseerr-api-key" ''
-        ${yq} -r .main.apiKey '${serviceCfgFile.jellyseerr}'
+      seerr = pkgs.writeShellScript "print-seerr-api-key" ''
+        ${yq} -r .main.apiKey '${serviceCfgFile.seerr}'
       '';
       sabnzbd = pkgs.writeShellScript "print-sabnzbd-api-key" ''
         ${grep} api_key '${serviceCfgFile.sabnzbd}' | ${sed} 's/^api_key.*= *//g'

--- a/nixarr/nixarr-command/default.nix
+++ b/nixarr/nixarr-command/default.nix
@@ -144,9 +144,9 @@ with lib; let
         chown -R ${globals.shelfmark.user}:root "${nixarr.shelfmark.stateDir}"
         find "${nixarr.shelfmark.stateDir}" \( -type d -exec chmod 0700 {} + -true \) -o \( -exec chmod 0600 {} + \)
       ''}
-        ${strings.optionalString nixarr.jellyseerr.enable ''
-        chown -R ${globals.jellyseerr.user}:root "${nixarr.jellyseerr.stateDir}"
-        find "${nixarr.jellyseerr.stateDir}" \( -type d -exec chmod 0700 {} + -true \) -o \( -exec chmod 0600 {} + \)
+        ${strings.optionalString nixarr.seerr.enable ''
+        chown -R ${globals.seerr.user}:root "${nixarr.seerr.stateDir}"
+        find "${nixarr.seerr.stateDir}" \( -type d -exec chmod 0700 {} + -true \) -o \( -exec chmod 0600 {} + \)
       ''}
         ${strings.optionalString nixarr.autobrr.enable ''
         chown -R ${globals.autobrr.user}:root "${nixarr.autobrr.stateDir}"
@@ -183,9 +183,9 @@ with lib; let
         BAZARR=$(yq '.auth.apikey' "${nixarr.bazarr.stateDir}/config/config.yaml")
         echo "Bazarr api-key: $BAZARR"
       ''}
-        ${strings.optionalString nixarr.jellyseerr.enable ''
-        JELLYSEERR=$(yq '.main.apiKey' "${nixarr.jellyseerr.stateDir}/settings.json")
-        echo "Jellyseerr api-key: $JELLYSEERR"
+        ${strings.optionalString nixarr.seerr.enable ''
+        SEERR=$(yq '.main.apiKey' "${nixarr.seerr.stateDir}/settings.json")
+        echo "Seerr api-key: $SEERR"
       ''}
         ${strings.optionalString nixarr.lidarr.enable ''
         LIDARR=$(xq '.Config.ApiKey' "${nixarr.lidarr.stateDir}/config.xml")
@@ -233,8 +233,8 @@ with lib; let
 
         echo "Wiping all nixarr users and groups from /etc/passwd and /etc/group..."
 
-        sed -i -E '/^(anchorr|audiobookshelf|autobrr|bazarr|cross-seed|jellyfin|jellyseerr|lidarr|plex|prowlarr|qbittorrent|radarr|readarr|recyclarr|sabnzbd|shelfmark|sonarr|streamer|torrenter|transmission|usenet|whisparr|komgarr)/d' /etc/passwd
-        sed -i -E '/^(anchorr|autobrr|cross-seed|jellyseerr|media|prowlarr|recyclarr|sabnzbd|streamer|torrenter|transmission|usenet)/d' /etc/group
+        sed -i -E '/^(anchorr|audiobookshelf|autobrr|bazarr|cross-seed|jellyfin|jellyseerr|lidarr|plex|prowlarr|qbittorrent|radarr|readarr|recyclarr|sabnzbd|seerr|shelfmark|sonarr|streamer|torrenter|transmission|usenet|whisparr|komgarr)/d' /etc/passwd
+        sed -i -E '/^(anchorr|autobrr|cross-seed|jellyseerr|media|prowlarr|recyclarr|sabnzbd|seerr|streamer|torrenter|transmission|usenet)/d' /etc/group
 
         echo ""
         echo "Done, please rebuild your configuration to get back the users and groups. This time, they will have the correct permissions."

--- a/nixarr/seerr/default.nix
+++ b/nixarr/seerr/default.nix
@@ -161,6 +161,35 @@ in {
       }
     ];
 
+    system.activationScripts.migrate-seerr-user = {
+      deps = [];
+      text = ''
+        if ${pkgs.gnugrep}/bin/grep -q '^jellyseerr:' /etc/passwd && ! ${pkgs.gnugrep}/bin/grep -q '^seerr:' /etc/passwd; then
+          echo "nixarr: renaming jellyseerr user to seerr in /etc/passwd"
+          ${pkgs.gnused}/bin/sed -i 's/^jellyseerr:/seerr:/' /etc/passwd
+        fi
+        if ${pkgs.gnugrep}/bin/grep -q '^jellyseerr:' /etc/group && ! ${pkgs.gnugrep}/bin/grep -q '^seerr:' /etc/group; then
+          echo "nixarr: renaming jellyseerr group to seerr in /etc/group"
+          ${pkgs.gnused}/bin/sed -i 's/^jellyseerr:/seerr:/' /etc/group
+        fi
+      '';
+    };
+
+    system.activationScripts.users.deps = lib.mkAfter ["migrate-seerr-user"];
+
+    system.activationScripts.migrate-seerr-state = {
+      # Must run after user migration so the renamed seerr user owns the moved directory
+      deps = ["users"];
+      text = let
+        oldDir = "${nixarr.stateDir}/jellyseerr";
+      in ''
+        if [ -d "${oldDir}" ] && [ ! -e "${cfg.stateDir}" ]; then
+          echo "nixarr: migrating Seerr state directory from ${oldDir} to ${cfg.stateDir}"
+          mv "${oldDir}" "${cfg.stateDir}"
+        fi
+      '';
+    };
+
     systemd.tmpfiles.rules = [
       "d '${cfg.stateDir}' 0700 ${globals.seerr.user} root - -"
     ];

--- a/nixarr/seerr/default.nix
+++ b/nixarr/seerr/default.nix
@@ -5,36 +5,36 @@
   ...
 }:
 with lib; let
-  cfg = config.nixarr.jellyseerr;
+  cfg = config.nixarr.seerr;
   globals = config.util-nixarr.globals;
   nixarr = config.nixarr;
   port = 5055;
 in {
-  options.nixarr.jellyseerr = {
+  options.nixarr.seerr = {
     enable = mkOption {
       type = types.bool;
       default = false;
       example = true;
       description = ''
-        Whether or not to enable the Jellyseerr service.
+        Whether or not to enable the Seerr service.
       '';
     };
 
-    package = mkPackageOption pkgs "jellyseerr" {};
+    package = mkPackageOption pkgs "seerr" {};
 
     stateDir = mkOption {
       type = types.path;
-      default = "${nixarr.stateDir}/jellyseerr";
-      defaultText = literalExpression ''"''${nixarr.stateDir}/jellyseerr"'';
-      example = "/nixarr/.state/jellyseerr";
+      default = "${nixarr.stateDir}/seerr";
+      defaultText = literalExpression ''"''${nixarr.stateDir}/seerr"'';
+      example = "/nixarr/.state/seerr";
       description = ''
-        The location of the state directory for the Jellyseerr service.
+        The location of the state directory for the Seerr service.
 
         > **Warning:** Setting this to any path, where the subpath is not
         > owned by root, will fail! For example:
         >
         > ```nix
-        >   stateDir = /home/user/nixarr/.state/jellyseerr
+        >   stateDir = /home/user/nixarr/.state/seerr
         > ```
         >
         > Is not supported, because `/home/user` is owned by `user`.
@@ -45,14 +45,14 @@ in {
       type = types.port;
       default = port;
       example = 12345;
-      description = "Jellyseerr web-UI port.";
+      description = "Seerr web-UI port.";
     };
 
     openFirewall = mkOption {
       type = types.bool;
       default = false;
       example = true;
-      description = "Open firewall for Jellyseerr";
+      description = "Open firewall for Seerr";
     };
 
     vpn.enable = mkOption {
@@ -62,9 +62,9 @@ in {
       description = ''
         **Required options:** [`nixarr.vpn.enable`](#nixarr.vpn.enable)
 
-        **Conflicting options:** [`nixarr.jellyseerr.expose.https.enable`](#nixarr.jellyseerr.expose.https.enable)
+        **Conflicting options:** [`nixarr.seerr.expose.https.enable`](#nixarr.seerr.expose.https.enable)
 
-        Route Jellyseerr traffic through the VPN.
+        Route Seerr traffic through the VPN.
       '';
     };
 
@@ -73,11 +73,11 @@ in {
       default = cfg.vpn.enable;
       example = false;
       description = ''
-        **Required options:** [`nixarr.jellyseerr.vpn.enable`)(#nixarr.jellyseerr.vpn.enable)
+        **Required options:** [`nixarr.seerr.vpn.enable`](#nixarr.seerr.vpn.enable)
 
-        Configure nginx as a reverse proxy for the Jellyseerr web ui.
+        Configure nginx as a reverse proxy for the Seerr web ui.
       '';
-      defaultText = literalExpression "nixarr.jellyseerr.vpn.enable";
+      defaultText = literalExpression "nixarr.seerr.vpn.enable";
     };
 
     expose = {
@@ -89,15 +89,15 @@ in {
           description = ''
             **Required options:**
 
-            - [`nixarr.jellyseerr.expose.https.acmeMail`](#nixarr.jellyseerr.expose.https.acmemail)
-            - [`nixarr.jellyseerr.expose.https.domainName`](#nixarr.jellyseerr.expose.https.domainname)
+            - [`nixarr.seerr.expose.https.acmeMail`](#nixarr.seerr.expose.https.acmemail)
+            - [`nixarr.seerr.expose.https.domainName`](#nixarr.seerr.expose.https.domainname)
 
-            **Conflicting options:** [`nixarr.jellyseerr.vpn.enable`](#nixarr.jellyseerr.vpn.enable)
+            **Conflicting options:** [`nixarr.seerr.vpn.enable`](#nixarr.seerr.vpn.enable)
 
-            Expose the Jellyseerr web service to the internet with https support,
+            Expose the Seerr web service to the internet with https support,
             allowing anyone to access it.
 
-            > **Warning:** Do _not_ enable this without setting up Jellyseerr
+            > **Warning:** Do _not_ enable this without setting up Seerr
             > authentication through localhost first!
           '';
         };
@@ -107,8 +107,8 @@ in {
         domainName = mkOption {
           type = types.nullOr types.str;
           default = null;
-          example = "jellyseerr.example.com";
-          description = "The domain name to host Jellyseerr on.";
+          example = "seerr.example.com";
+          description = "The domain name to host Seerr on.";
         };
 
         acmeMail = mkOption {
@@ -126,22 +126,22 @@ in {
       {
         assertion = cfg.vpn.enable -> nixarr.vpn.enable;
         message = ''
-          The nixarr.jellyseerr.vpn.enable option requires the
+          The nixarr.seerr.vpn.enable option requires the
           nixarr.vpn.enable option to be set, but it was not.
         '';
       }
       {
         assertion = !(cfg.vpn.enable && cfg.expose.https.enable);
         message = ''
-          The nixarr.jellyseerr.vpn.enable option conflicts with the
-          nixarr.jellyseerr.expose.https.enable option. You cannot set both.
+          The nixarr.seerr.vpn.enable option conflicts with the
+          nixarr.seerr.expose.https.enable option. You cannot set both.
         '';
       }
       {
         assertion = cfg.vpn.configureNginx -> cfg.vpn.enable;
         message = ''
-          The nixarr.jellyseerr.vpn.configureNginx option requires the
-          nixarr.jellyseerr.vpn.enable option to be set, but it was not.
+          The nixarr.seerr.vpn.configureNginx option requires the
+          nixarr.seerr.vpn.enable option to be set, but it was not.
         '';
       }
       {
@@ -152,21 +152,21 @@ in {
             && (cfg.expose.https.acmeMail != null)
           );
         message = ''
-          The nixarr.jellyseerr.expose.https.enable option requires the
+          The nixarr.seerr.expose.https.enable option requires the
           following options to be set, but one of them were not:
 
-          - nixarr.jellyseerr.expose.https.domainName
-          - nixarr.jellyseerr.expose.https.acmeMail
+          - nixarr.seerr.expose.https.domainName
+          - nixarr.seerr.expose.https.acmeMail
         '';
       }
     ];
 
     systemd.tmpfiles.rules = [
-      "d '${cfg.stateDir}' 0700 ${globals.jellyseerr.user} root - -"
+      "d '${cfg.stateDir}' 0700 ${globals.seerr.user} root - -"
     ];
 
-    systemd.services.jellyseerr = {
-      description = "Jellyseerr, a requests manager for Jellyfin";
+    systemd.services.seerr = {
+      description = "Open-source media request and discovery manager for Jellyfin, Plex, and Emby";
       after = ["network.target"];
       wantedBy = ["multi-user.target"];
       environment = {
@@ -176,10 +176,10 @@ in {
 
       serviceConfig = {
         Type = "exec";
-        StateDirectory = "jellyseerr";
+        StateDirectory = "seerr";
         DynamicUser = false;
-        User = globals.jellyseerr.user;
-        Group = globals.jellyseerr.group;
+        User = globals.seerr.user;
+        Group = globals.seerr.group;
         ExecStart = lib.getExe cfg.package;
         Restart = "on-failure";
 
@@ -204,11 +204,11 @@ in {
     };
 
     users = {
-      groups.${globals.jellyseerr.group}.gid = globals.gids.${globals.jellyseerr.group};
-      users.${globals.jellyseerr.user} = {
+      groups.${globals.seerr.group}.gid = globals.gids.${globals.seerr.group};
+      users.${globals.seerr.user} = {
         isSystemUser = true;
-        group = globals.jellyseerr.group;
-        uid = globals.uids.${globals.jellyseerr.user};
+        group = globals.seerr.group;
+        uid = globals.uids.${globals.seerr.user};
       };
     };
 
@@ -268,7 +268,7 @@ in {
     };
 
     # Enable and specify VPN namespace to confine service in.
-    systemd.services.jellyseerr.vpnConfinement = mkIf cfg.vpn.enable {
+    systemd.services.seerr.vpnConfinement = mkIf cfg.vpn.enable {
       enable = true;
       vpnNamespace = "wg";
     };

--- a/nixarr/seerr/default.nix
+++ b/nixarr/seerr/default.nix
@@ -20,7 +20,11 @@ in {
       '';
     };
 
-    package = mkPackageOption pkgs "seerr" {};
+    package = mkPackageOption pkgs (
+      if lib.versionAtLeast lib.version "26.05pre"
+      then "seerr"
+      else "jellyseerr"
+    ) {};
 
     stateDir = mkOption {
       type = types.path;

--- a/tests/anchorr-test.nix
+++ b/tests/anchorr-test.nix
@@ -32,13 +32,13 @@ pkgs.testers.nixosTest {
       };
     };
 
-    # Mock jellyseerr API key extraction since we don't want to run full jellyseerr
-    systemd.services.jellyseerr-api-key = {
-      serviceConfig.ExecStart = lib.mkForce (pkgs.writeShellScript "mock-jellyseerr-api-key" ''
-        mkdir -p /data/.state/nixarr/api-keys
-        echo "mock-jellyseerr-key" > /data/.state/nixarr/api-keys/jellyseerr.key
-        chown root:jellyseerr-api /data/.state/nixarr/api-keys/jellyseerr.key
-        chmod 640 /data/.state/nixarr/api-keys/jellyseerr.key
+    # Mock seerr API key extraction since we don't want to run full seerr
+    systemd.services.seerr-api = {
+      serviceConfig.ExecStart = lib.mkForce (pkgs.writeShellScript "mock-seerr-api-key" ''
+        mkdir -p /data/.state/nixarr/secrets
+        echo "mock-jellyseerr-key" > /data/.state/nixarr/secrets/seerr.api-key
+        chown root:seerr-api /data/.state/nixarr/secrets/seerr.api-key
+        chmod 640 /data/.state/nixarr/secrets/seerr.api-key
       '');
     };
   };

--- a/tests/simple-test.nix
+++ b/tests/simple-test.nix
@@ -23,7 +23,7 @@ pkgs.testers.nixosTest {
 
       jellyfin.enable = true;
       plex.enable = true;
-      jellyseerr.enable = true;
+      seerr.enable = true;
       audiobookshelf.enable = true;
 
       transmission = {
@@ -107,7 +107,7 @@ pkgs.testers.nixosTest {
 
     # Check that all services are operational
     machine.succeed("systemctl is-active jellyfin")
-    machine.succeed("systemctl is-active jellyseerr")
+    machine.succeed("systemctl is-active seerr")
     machine.succeed("systemctl is-active audiobookshelf")
     machine.succeed("systemctl is-active plex")
     machine.succeed("systemctl is-active transmission")

--- a/tests/vpn-confinement-test.nix
+++ b/tests/vpn-confinement-test.nix
@@ -424,7 +424,7 @@ in
           sabnzbd.enable = false;
           autobrr.enable = false;
           recyclarr.enable = false;
-          jellyseerr.enable = false;
+          seerr.enable = false;
         };
 
         # Add IPv6 route for VPN namespace to reach internetClient via WireGuard

--- a/util/globals/default.nix
+++ b/util/globals/default.nix
@@ -28,7 +28,8 @@ in {
       bazarr = 232;
       lidarr = 306;
       prowlarr = 293;
-      jellyseerr = 262;
+      jellyseerr = 262; # kept for migration; remove once seerr rename is established
+      seerr = 262;
       komga = 145;
       sonarr = 274;
       radarr = 275;
@@ -50,7 +51,8 @@ in {
       autobrr = 188;
       # Removed 2025-10-29
       # cross-seed = 183;
-      jellyseerr = 250;
+      jellyseerr = 250; # kept for migration; remove once seerr rename is established
+      seerr = 250;
       media = 169;
       prowlarr = 287;
       recyclarr = 269;
@@ -80,6 +82,10 @@ in {
     jellyseerr = {
       user = "jellyseerr";
       group = "jellyseerr";
+    };
+    seerr = {
+      user = "seerr";
+      group = "seerr";
     };
     komga = {
       user = "komga";


### PR DESCRIPTION
Jellyseer has been renamed upstream to just "Seerr" (see https://github.com/NixOS/nixpkgs/commit/42d2e1ccf6e50d11ddc6a6523a00346e1f9456f5, currently only on `nixos-unstable`)
This PR renames `jellyseerr` to `seerr`

Full list of changes:
- move `jellyseerr/` to `seerr/`
- add a deprecation stub to `jellyseerr/` that allows existing configs to work as usual but with eval warnings
- add `seerr` user and group with the same GID as the existing `jellyseerr` ones
- add `activationScripts` that rename the existing user and migrate the state dir
- uses `nixpkgs#seerr` instead of `nixpkgs#jellyseerr` when on newer nixpkgs, fixing the nixpkgs eval warning on unstable