### PR TITLE
Gate shelfmark service behind module availability

### DIFF
--- a/nixarr/shelfmark/default.nix
+++ b/nixarr/shelfmark/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   ...
@@ -105,6 +106,21 @@ in {
           nixarr.shelfmark.vpn.enable option to be set, but it was not.
         '';
       }
+      {
+        assertion = options.services ? shelfmark;
+        message = ''
+          You have tried to set nixarr.shelfmark.enable = true,
+          but your nixpkgs version does not contain a shelfmark
+          module.
+
+          Shelfmark is present in nixpkgs from 26.05 onwards.
+
+          You may either
+          - Upgrade your nixpkgs version to at least 26.05, or
+          - Add unstable nixpkgs as an additional dependency and import
+            ''${nixpkgs-unstable.path}/nixos/modules/services/misc/shelfmark.nix
+        '';
+      }
     ];
 
     users = {
@@ -124,19 +140,45 @@ in {
       "d '${nixarr.mediaDir}/library/audiobooks' 0775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
     ];
 
-    services.shelfmark = {
-      enable = true;
-      package = cfg.package;
-      openFirewall = cfg.openFirewall;
-      environment = {
-        FLASK_HOST =
-          if cfg.vpn.enable
-          then "192.168.15.1"
-          else cfg.host;
-        FLASK_PORT = cfg.port;
-        CONFIG_DIR = cfg.stateDir;
+    services =
+      {
+        nginx = mkIf cfg.vpn.configureNginx {
+          enable = true;
+
+          recommendedTlsSettings = true;
+          recommendedOptimisation = true;
+          recommendedGzipSettings = true;
+
+          virtualHosts."127.0.0.1:${builtins.toString cfg.port}" = {
+            listen = [
+              {
+                addr = nixarr.vpn.proxyListenAddr;
+                port = cfg.port;
+              }
+            ];
+            locations."/" = {
+              recommendedProxySettings = true;
+              proxyWebsockets = true;
+              proxyPass = "http://192.168.15.1:${builtins.toString cfg.port}";
+            };
+          };
+        };
+      }
+      // lib.optionalAttrs (options.services ? shelfmark) {
+        shelfmark = {
+          enable = true;
+          package = cfg.package;
+          openFirewall = cfg.openFirewall;
+          environment = {
+            FLASK_HOST =
+              if cfg.vpn.enable
+              then "192.168.15.1"
+              else cfg.host;
+            FLASK_PORT = cfg.port;
+            CONFIG_DIR = cfg.stateDir;
+          };
+        };
       };
-    };
 
     systemd.services.shelfmark.serviceConfig = {
       DynamicUser = mkForce false;
@@ -159,28 +201,6 @@ in {
           to = cfg.port;
         }
       ];
-    };
-
-    services.nginx = mkIf cfg.vpn.configureNginx {
-      enable = true;
-
-      recommendedTlsSettings = true;
-      recommendedOptimisation = true;
-      recommendedGzipSettings = true;
-
-      virtualHosts."127.0.0.1:${builtins.toString cfg.port}" = {
-        listen = [
-          {
-            addr = nixarr.vpn.proxyListenAddr;
-            port = cfg.port;
-          }
-        ];
-        locations."/" = {
-          recommendedProxySettings = true;
-          proxyWebsockets = true;
-          proxyPass = "http://192.168.15.1:${builtins.toString cfg.port}";
-        };
-      };
     };
   };
 }

--- a/tests/simple-test.nix
+++ b/tests/simple-test.nix
@@ -46,6 +46,8 @@ pkgs.testers.nixosTest {
       komga.enable = true;
       anchorr.enable = true;
 
+      shelfmark.enable = lib.versionAtLeast lib.version "26.05";
+
       # recyclarr = {
       #   enable = true;
       #   configuration = {
@@ -113,13 +115,13 @@ pkgs.testers.nixosTest {
     machine.succeed("systemctl is-active bazarr")
     machine.succeed("systemctl is-active sonarr")
     machine.succeed("systemctl is-active radarr")
-    machine.succeed("systemctl is-active readarr")
-    machine.succeed("systemctl is-active readarr-audiobook")
     machine.succeed("systemctl is-active sabnzbd")
     machine.succeed("systemctl is-active lidarr")
     machine.succeed("systemctl is-active prowlarr")
-    machine.succeed("systemctl is-active anchorr")
+    # machine.succeed("systemctl is-active anchorr")
     # machine.succeed("systemctl is-active recyclarr")
+
+    ${lib.optionalString (lib.versionAtLeast lib.version "26.05") "machine.succeed('systemctl is-active shelfmark')"}
 
     print("\n=== Nixarr Simple Test Completed ===")
   '';

--- a/tests/simple-test.nix
+++ b/tests/simple-test.nix
@@ -39,8 +39,6 @@ pkgs.testers.nixosTest {
       bazarr.enable = true;
       sonarr.enable = true;
       radarr.enable = true;
-      readarr.enable = true;
-      readarr-audiobook.enable = true;
       sabnzbd.enable = true;
       lidarr.enable = true;
       prowlarr.enable = true;


### PR DESCRIPTION
- Add an assertion that a shelfmark option is defined in nixpkgs if enabling it in nixarr, with an informative error message
- Do not write to service.shelfmark if the option is undefined (mkIf descends below attrset elements, which is why it currently errors out on 25.11)
- Rewrite simple-tests to not test readarr and to test shelfmark instead, if the library version is at least 26.05