### PR TITLE
Add tmpfiles rule for Sonarr state directory

### DIFF
--- a/nixarr/sonarr/default.nix
+++ b/nixarr/sonarr/default.nix
@@ -108,6 +108,7 @@ in {
     };
 
     systemd.tmpfiles.rules = [
+      "d '${cfg.stateDir}' 0700 ${globals.sonarr.user} root - -"
       "d '${nixarr.mediaDir}/library'        2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
       "d '${nixarr.mediaDir}/library/shows'  2775 ${globals.libraryOwner.user} ${globals.libraryOwner.group} - -"
     ];


### PR DESCRIPTION
Sonarr service now needs the state directory to exist if not default.

`The Sonarr home directory used to store all data. If left as the default value this directory will automatically be created before the Sonarr server starts, otherwise you are responsible for ensuring the directory exists with appropriate ownership and permissions.`