### PR TITLE
seerr: fix migration bug for userborn/sysusers users

### DIFF
--- a/nixarr/seerr/default.nix
+++ b/nixarr/seerr/default.nix
@@ -170,11 +170,11 @@ in {
       text = ''
         if ${pkgs.gnugrep}/bin/grep -q '^jellyseerr:' /etc/passwd && ! ${pkgs.gnugrep}/bin/grep -q '^seerr:' /etc/passwd; then
           echo "nixarr: renaming jellyseerr user to seerr in /etc/passwd"
-          ${pkgs.gnused}/bin/sed -i 's/^jellyseerr:/seerr:/' /etc/passwd
+          ${pkgs.gnused}/bin/sed -i --follow-symlinks 's/^jellyseerr:/seerr:/' /etc/passwd
         fi
         if ${pkgs.gnugrep}/bin/grep -q '^jellyseerr:' /etc/group && ! ${pkgs.gnugrep}/bin/grep -q '^seerr:' /etc/group; then
           echo "nixarr: renaming jellyseerr group to seerr in /etc/group"
-          ${pkgs.gnused}/bin/sed -i 's/^jellyseerr:/seerr:/' /etc/group
+          ${pkgs.gnused}/bin/sed -i --follow-symlinks 's/^jellyseerr:/seerr:/' /etc/group
         fi
       '';
     };

--- a/nixarr/seerr/default.nix
+++ b/nixarr/seerr/default.nix
@@ -179,7 +179,11 @@ in {
       '';
     };
 
-    system.activationScripts.users.deps = lib.mkAfter ["migrate-seerr-user"];
+    # nixpkgs sets system.activationScripts.users to "" under sysusers/userborn
+    system.activationScripts.users =
+      lib.mkIf
+      (!(config.systemd.sysusers.enable or false) && !(config.services.userborn.enable or false))
+      {deps = lib.mkAfter ["migrate-seerr-user"];};
 
     system.activationScripts.migrate-seerr-state = {
       # Must run after user migration so the renamed seerr user owns the moved directory


### PR DESCRIPTION
When migrating jellyseerr to seerr, the newly added migration script referenced `system.activationScripts.users`, which is unset when userborn or sysusers are enabled.
This PR gates it, and fixes a potential latent bug for userborn users in the migration script.

Closes #162

@strangeglyph, could you test this on your setup? I tried it in a NixOS VM test but not in a "real" setup