### PR TITLE
fix(recyclarr): v8 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Fixed:
 - qBittorrent `fix-permissions` now uses the correct download path.
 - Jellyfin authentication cleaned up: uses shared API key instead of creating
   a new device UUID per connection.
+- **Recyclarr v8 compatibility**: `--app-data` was removed in recyclarr v8.0.0
+    in favor of `RECYCLARR_CONFIG_DIR` and `RECYCLARR_DATA_DIR` env vars.
 
 Removed:
 - Readarr and Readarr-audiobook, use shelfmark

--- a/nixarr/recyclarr/default.nix
+++ b/nixarr/recyclarr/default.nix
@@ -254,8 +254,13 @@ in {
     systemd.services.recyclarr = {
       requires = ["recyclarr-setup.service"];
       after = ["recyclarr-setup.service"];
+
       serviceConfig = {
-        ExecStart = lib.mkForce "${cfg.package}/bin/recyclarr sync --app-data ${cfg.stateDir} --config ${effectiveConfigFile}";
+        ExecStart = lib.mkForce "${cfg.package}/bin/recyclarr sync --config ${effectiveConfigFile}";
+        Environment = lib.mkForce [
+          "RECYCLARR_CONFIG_DIR=${cfg.stateDir}"
+          "RECYCLARR_DATA_DIR=${cfg.stateDir}"
+        ];
         EnvironmentFile = "${cfg.stateDir}/env";
         ReadWritePaths = [cfg.stateDir];
       };


### PR DESCRIPTION
Recyclarr v8+ has changed the CLI commands. `--app-data` has been removed in favor of `RECYCLARR_CONFIG_DIR` and `RECYCLARR_DATA_DIR` environment variables.

Note: `RECYCLARR_DATA_DIR` is not strictly necessary, since not setting it defaults it to `RECYCLARR_CONFIG_DIR`. It is explicitly set for visibility and to make it easier to expose as a user-configurable option in the future (if needed).

This should only be merged when the new Stable Channel 26.05 has been pinned.