### PR TITLE
fix(sabnzbd): respect nixarrs statedir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Fixed:
 - qBittorrent `fix-permissions` now uses the correct download path.
 - Jellyfin authentication cleaned up: uses shared API key instead of creating
   a new device UUID per connection.
+- Sabnzbd: config now uses `nixarr` state directory instead of upstream default path `/var/lib`.
 
 Removed:
 - Readarr and Readarr-audiobook, use shelfmark

--- a/nixarr/sabnzbd/default.nix
+++ b/nixarr/sabnzbd/default.nix
@@ -339,7 +339,7 @@ in {
           )
         );
     in {
-      systemd.services.sabnzbd.serviceConfig.ExecStart = lib.mkForce "${cfg.package}/bin/sabnzbd -d -f ${cfg.stateDir}/sabnzbd.ini";
+      systemd.services.sabnzbd.serviceConfig.BindPaths = ["${cfg.stateDir}:/var/lib/${config.services.sabnzbd.stateDir}"];
       services.sabnzbd = {
         settings = {
           misc = {

--- a/nixarr/sabnzbd/default.nix
+++ b/nixarr/sabnzbd/default.nix
@@ -339,6 +339,7 @@ in {
           )
         );
     in {
+      systemd.services.sabnzbd.serviceConfig.ExecStart = lib.mkForce "${cfg.package}/bin/sabnzbd -d -f ${cfg.stateDir}/sabnzbd.ini";
       services.sabnzbd = {
         settings = {
           misc = {


### PR DESCRIPTION
## Summary

The update to the new stable sabnzbd broke the `.ini` location since we no longer set it.
It is not possible to use `services.sabnzbd.stateDir`, since this is just the dir relative to `/var/lib`. 
The config dir is hardcoded upstream with `/var/lib` so the override is necessary.

This PR will fix #169 