### PR TITLE
fix(vpn): actually exposeOnLan (RFC 1918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Fixed:
 - qBittorrent `fix-permissions` now uses the correct download path.
 - Jellyfin authentication cleaned up: uses shared API key instead of creating
   a new device UUID per connection.
+- `nixarr.vpn.exposeOnLan` now exposes on all RFC 1918 private IP ranges.
 
 Removed:
 - Readarr and Readarr-audiobook, use shelfmark

--- a/nixarr/default.nix
+++ b/nixarr/default.nix
@@ -225,9 +225,10 @@ in {
         description = ''
           Whether to allow direct LAN access to VPN-confined services. When
           enabled (default), services are accessible from the local network
-          (192.168.0.0/24 and 192.168.1.0/24). When disabled, services are
-          only accessible from localhost (127.0.0.1), which is useful when
-          using a reverse proxy like Caddy for all external access.
+          (all RFC 1918 private ranges: 10.0.0.0/8, 172.16.0.0/12,
+          192.168.0.0/16). When disabled, services are only accessible from
+          localhost (127.0.0.1), which is useful when using a reverse proxy
+          like Caddy for all external access.
 
           This is controlled by the VPN namespace firewall rules via the
           accessibleFrom configuration.
@@ -267,8 +268,9 @@ in {
         (
           if cfg.vpn.exposeOnLAN
           then [
-            "192.168.1.0/24"
-            "192.168.0.0/24"
+            "10.0.0.0/8"
+            "172.16.0.0/12"
+            "192.168.0.0/16"
             "127.0.0.1"
           ]
           else ["127.0.0.1"]


### PR DESCRIPTION
- original implementation only exposed 192.168.0.0/24 and 192.168.1.0/24
- now exposes on all RFC 1918 private address ranges