### PR TITLE
Add Jellyfin 10.11.11 OpenAPI hash

### DIFF
--- a/nixarr/lib/nixarr-py/python-deps.nix
+++ b/nixarr/lib/nixarr-py/python-deps.nix
@@ -156,6 +156,7 @@
           "10.11.8" = "sha256-Fqzv/r1ntNn9/wPSD1wRvH9rUyjjBV0lrxw3hdBgrtA=";
           "10.11.9" = "sha256-3+QrbX658CN46/qfAh3Yj7sRDn50fMlLQvckSHTVuFk=";
           "10.11.10" = "sha256-3FfqhqQfuQdM/02NyhAWDW7H6OaTynWtaUBoSIxk4AQ=";
+          "10.11.11" = "sha256-4p/DaeyuVGdsrrUMu8AGtcTulZkGwA8eAvb4PbnCJ/s=";
         })."${jellyfin.version}";
     };
     openapi-config = writeTextFile {


### PR DESCRIPTION
New Jellyfin version released four days ago and has made its way into `nixpkgs`. Update nixarr to support it.