### PR TITLE
fix: runner issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,11 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v3
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
 
       - run: nix fmt -- --no-cache --fail-on-change
 
@@ -28,9 +30,11 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v3
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
 
       - run: nix build
 
@@ -40,8 +44,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v3
+        uses: DeterminateSystems/nix-installer-action@v22
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
 
-      - run: nix flake check
+      - run: nix flake check --max-jobs 1


### PR DESCRIPTION
## Summary

Reason for runner failure seems to have been that KVM was not active. Initially I activated it as documented [here](https://github.blog/changelog/2024-04-02-github-actions-hardware-accelerated-android-virtualization-now-available/). 
After getting the tests to pass, I wanted to fix the Warnings and Errors in the pipeline itself, so I updated the Actions while at it:
- nix-installer-action v3 -> v22
- magic-nix-cache-action v8 -> v14 with `use-flakehub: false` (since this repo does not have a org at Flakehub anyway)

Somewhere between v3 and v22 they added automatic KVM activation, so the manual activation step wasn't needed anymore.

Running without `--max-jobs 1` still causes occasional issues and this is worth investigating separately, but for now: the pipeline is green again!